### PR TITLE
fix(extract): stop chroma cleanup from destroying subject colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `sprite-gen` are recorded here. Versions track the `version:` field in `SKILL.md`.
 
+## Unreleased — Chroma extraction no longer eats subject colors
+
+Extraction fixes for subjects whose colors share a channel with the chroma key (e.g. a red/orange body under magenta, or any subject with small green/teal features).
+
+- **Despill no longer destroys colors far from the key.** `remove_chroma_background` ran its "neutralize key tint" pass on every pixel whose channels leaned toward the key's, with *no distance gate* — so a saturated red/orange/blue subject was clamped toward olive/grey under a magenta key even at color-distance 200+. The destructive pass is removed (it only ever fired on pixels the fringe stage had already decided to keep); near-key antialias fringe is still removed as before. `neutralize_key_tint` is dropped.
+- **`--chroma-key auto` stops silently deleting small features.** Candidate scoring ranked by the 1st-percentile distance to subject pixels, which discards sub-1% features (eyes, gems, ear lamps): a key could look "safe" while its nearest subject pixel was still inside the erase radius. `auto` now prefers candidates that clear *every* subject pixel, records `min_subject_distance`, and warns on stderr when none do.
+- Regression coverage in `tests/test_chroma_extraction.py`; the golden extraction manifest is unchanged.
+
 ## v1.9.1 — Docs sync & polish
 
 Catch the docs and repo up to the v1.8–v1.9 curator (from an evaluator-grade consistency audit).

--- a/SKILL.md
+++ b/SKILL.md
@@ -410,15 +410,15 @@ If image generation produces guide boxes, visible labels, overlapping poses, bac
 
 `prepare_sprite_run.py` chooses a chroma key by sampling the base image unless the request forces one. The generated character must not use the chroma color or chroma-adjacent colors.
 
-**Choose the chroma away from the subject's dominant hue — do not blindly default to magenta.** `extract_sprite_row_frames.py` neutralizes chroma-adjacent tint, so any character color that sits near the key gets eaten. The failure is hue-adjacency, not exact match:
+**Choose the chroma away from the subject's dominant hue — do not blindly default to magenta.** `extract_sprite_row_frames.py` removes chroma-adjacent antialias fringe, so a character color that sits *near* the key (within the fringe distance) gets eaten. Colors far from the key are kept intact (a saturated red body no longer turns olive under a magenta key), but the failure is still hue-adjacency, not exact match:
 
 - Deep-red / crimson / wine hair or clothing is **magenta-adjacent** (both high R). Magenta keying turns red hair near-black after extraction. Use **green** for red/crimson/warm subjects.
 - Green/teal/olive subjects → use **magenta**.
 - Blue subjects → avoid cyan/blue keys; magenta or green.
 
-When unsure, let `--chroma-key auto` sample the base (it scores candidates by distance from subject pixels). Only force a key when you know the subject hue is safely far from it. Verify after extraction that the dominant subject color survived — a black-where-it-should-be-colored frame means the key was adjacent to the subject.
+When unsure, let `--chroma-key auto` sample the base (it scores candidates by distance from subject pixels). `auto` now also refuses a key whose nearest subject pixel falls inside the erase radius when a safer candidate exists, records `min_subject_distance` in the request, and warns (stderr) when no candidate clears the subject — so a small but critical feature (eyes, a gem, an ear lamp) under 1% of the pixels is not silently deleted. Only force a key when you know the subject hue is safely far from it. Verify after extraction that the dominant subject color survived — a black-where-it-should-be-colored frame means the key was adjacent to the subject.
 
-`extract_sprite_row_frames.py` owns alpha cleanup for sprite rows. It removes pixels near the chroma key, removes chroma-tinted antialias fringe, neutralizes remaining key-color tint, clears fully transparent RGB, extracts connected components, and writes fresh transparent cells. This is intentionally closer to hatch-pet than to simple `magick -transparent`.
+`extract_sprite_row_frames.py` owns alpha cleanup for sprite rows. It removes pixels near the chroma key, removes chroma-tinted antialias fringe within the fringe band, clears fully transparent RGB, extracts connected components, and writes fresh transparent cells. This is intentionally closer to hatch-pet than to simple `magick -transparent`.
 
 If component extraction cannot find the declared frame count, the row is blocked. `--allow-slot-fallback` exists for explicit debugging only; it must be reported as `slots-explicit` and is not the default path.
 

--- a/scripts/extract_sprite_row_frames.py
+++ b/scripts/extract_sprite_row_frames.py
@@ -48,18 +48,6 @@ def key_tint_score(color: tuple[int, int, int], chroma_key: tuple[int, int, int]
     return keyed_average - unkeyed_average
 
 
-def neutralize_key_tint(color: tuple[int, int, int], chroma_key: tuple[int, int, int]) -> tuple[int, int, int]:
-    keyed_channels = [index for index, value in enumerate(chroma_key) if value >= 192]
-    unkeyed_channels = [index for index, value in enumerate(chroma_key) if value < 64]
-    if not keyed_channels or not unkeyed_channels:
-        neutral = round(sum(color) / 3)
-    else:
-        neutral = round(sum(color[index] for index in unkeyed_channels) / len(unkeyed_channels))
-    output = list(color)
-    for index in keyed_channels:
-        output[index] = min(output[index], neutral)
-    return tuple(output)
-
 
 def remove_chroma_background(
     image: Image.Image,
@@ -79,9 +67,6 @@ def remove_chroma_background(
                 pixels[x, y] = (0, 0, 0, 0)
             elif alpha and distance <= fringe_threshold and key_tint_score(color, chroma_key) >= fringe_delta:
                 pixels[x, y] = (0, 0, 0, 0)
-            elif alpha and key_tint_score(color, chroma_key) >= fringe_delta * 2:
-                neutral_red, neutral_green, neutral_blue = neutralize_key_tint(color, chroma_key)
-                pixels[x, y] = (neutral_red, neutral_green, neutral_blue, alpha)
             elif alpha == 0 and (red or green or blue):
                 pixels[x, y] = (0, 0, 0, 0)
     return rgba

--- a/scripts/prepare_sprite_run.py
+++ b/scripts/prepare_sprite_run.py
@@ -14,6 +14,7 @@ import json
 import math
 import re
 import shutil
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -223,6 +224,12 @@ def sampled_reference_pixels(path: Path | None) -> list[tuple[int, int, int]]:
     return pixels
 
 
+# Mirrors the default --key-threshold in extract_sprite_row_frames.py: any subject
+# pixel within this color distance of the chroma key is removed at extraction, so a
+# key whose nearest subject pixel falls inside this radius will erase that feature.
+MIN_SUBJECT_KEY_DISTANCE = 96.0
+
+
 def choose_chroma_key(reference: Path | None, requested: str) -> dict[str, Any]:
     if requested.lower() != "auto":
         rgb = parse_hex_color(requested)
@@ -235,20 +242,35 @@ def choose_chroma_key(reference: Path | None, requested: str) -> dict[str, Any]:
         rgb = parse_hex_color("#FF00FF")
         return {"name": "magenta", "hex": "#FF00FF", "rgb": list(rgb), "selection": "fallback"}
 
-    scored: list[tuple[float, int, str, tuple[int, int, int]]] = []
+    scored: list[tuple[float, float, int, str, tuple[int, int, int]]] = []
     for preference_index, (name, hex_color) in enumerate(CHROMA_CANDIDATES):
         rgb = parse_hex_color(hex_color)
         distances = sorted(color_distance(rgb, pixel) for pixel in pixels)
         percentile_index = max(0, min(len(distances) - 1, int(len(distances) * 0.01)))
-        scored.append((distances[percentile_index], -preference_index, name, rgb))
-    score, _preference, name, rgb = max(scored)
-    return {
+        scored.append((distances[percentile_index], distances[0], -preference_index, name, rgb))
+
+    # Rank by the 1st-percentile distance, but that metric ignores sub-1% features
+    # (eyes, gems, ear lamps): a key can look "safe" while its nearest subject pixel
+    # is still inside the erase radius. Prefer candidates that clear every subject
+    # pixel; only fall back to the raw ranking (with a warning) when none do.
+    safe = [entry for entry in scored if entry[1] > MIN_SUBJECT_KEY_DISTANCE]
+    score, min_distance, _preference, name, rgb = max(safe) if safe else max(scored)
+    result = {
         "name": name,
         "hex": rgb_to_hex(rgb),
         "rgb": list(rgb),
         "selection": "auto",
         "score": round(score, 2),
+        "min_subject_distance": round(min_distance, 2),
     }
+    if min_distance <= MIN_SUBJECT_KEY_DISTANCE:
+        result["warning"] = (
+            f"nearest subject pixel is {min_distance:.1f} from {name} "
+            f"(<= {MIN_SUBJECT_KEY_DISTANCE:.0f}); that feature will be erased at extraction — "
+            f"recolor it or force a different --chroma-key"
+        )
+        print(f"WARNING: chroma_key auto: {result['warning']}", file=sys.stderr)
+    return result
 
 
 def normalize_states(raw: dict[str, Any] | None) -> dict[str, dict[str, Any]]:

--- a/tests/test_chroma_extraction.py
+++ b/tests/test_chroma_extraction.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for chroma-key alpha cleanup and auto key selection.
+
+These guard two ways the extractor used to silently destroy real subject
+colors:
+
+1. ``remove_chroma_background`` ran a "neutralize key tint" pass on every pixel
+   whose channels leaned toward the key's channels, *regardless of color
+   distance* — so a saturated red/orange/blue subject was clamped toward
+   olive/grey under a magenta key even though it sat >200 away from magenta.
+   The destructive pass is gone; near-key antialias fringe is still removed.
+2. ``choose_chroma_key`` ranked candidates by the 1st-percentile distance to
+   subject pixels, which discards sub-1% features (eyes, gems, ear lamps): the
+   auto key could look safe while its nearest subject pixel was still inside the
+   extraction erase radius and would be deleted.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+from PIL import Image
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, SCRIPTS_DIR / f"{name}.py")
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+extract = _load("extract_sprite_row_frames")
+prepare = _load("prepare_sprite_run")
+
+MAGENTA = (255, 0, 255)
+# extract_sprite_row_frames.py main() defaults
+KEY_THRESHOLD = 96.0
+FRINGE_THRESHOLD = 180.0
+FRINGE_DELTA = 18.0
+
+
+def _key(pixel: tuple[int, int, int], chroma_key=MAGENTA):
+    image = Image.new("RGBA", (1, 1), (*pixel, 255))
+    out = extract.remove_chroma_background(image, chroma_key, KEY_THRESHOLD, FRINGE_THRESHOLD, FRINGE_DELTA)
+    return out.getpixel((0, 0))
+
+
+def test_despill_preserves_far_subject_colors() -> None:
+    # All of these sit >200 color-distance away from magenta: they are the
+    # subject, not key fringe, and must survive completely untouched.
+    for pixel in [(196, 54, 38), (224, 96, 40), (208, 44, 40), (40, 70, 200)]:
+        assert extract.color_distance(pixel, MAGENTA) > FRINGE_THRESHOLD
+        assert _key(pixel) == (*pixel, 255), f"{pixel} was mangled by despill"
+
+
+def test_despill_still_removes_key_and_fringe() -> None:
+    # Exact key -> fully transparent.
+    assert _key(MAGENTA)[3] == 0
+    # A magenta antialias fringe (the key blended with a green subject edge)
+    # sits inside FRINGE_THRESHOLD with a strong key tint and must still go.
+    fringe = (147, 90, 157)
+    assert extract.color_distance(fringe, MAGENTA) <= FRINGE_THRESHOLD
+    assert extract.key_tint_score(fringe, MAGENTA) >= FRINGE_DELTA
+    assert _key(fringe)[3] == 0
+
+
+# A small, cyan-leaning teal feature: ~55 from the cyan key, so cyan would erase
+# it, yet it is far enough from magenta/green/blue for those to keep it.
+EYE = (0, 250, 200)
+
+
+def _reference_image(path: Path) -> None:
+    # 128px so PIL never downscales the sample (deterministic across platforms).
+    image = Image.new("RGBA", (128, 128), (0, 0, 0, 0))
+    pixels = image.load()
+    for y in range(128):
+        for x in range(128):
+            if (x - 64) ** 2 + (y - 64) ** 2 < 58 ** 2:
+                pixels[x, y] = (196, 54, 38, 255)  # red-orange body (the bulk hue)
+    # Two tiny eyes: well under 1% of the subject, so the 1st-percentile ranking
+    # ignores them and a naive selector happily picks the cyan key that erases them.
+    for cx, cy in ((50, 52), (78, 52)):
+        for dy in range(-1, 2):
+            for dx in range(-2, 3):
+                pixels[cx + dx, cy + dy] = (*EYE, 255)
+    image.save(path)
+
+
+def test_auto_key_avoids_erasing_small_feature(tmp_path: Path) -> None:
+    ref = tmp_path / "base.png"
+    _reference_image(ref)
+
+    opaque = eyes = 0
+    with Image.open(ref) as opened:
+        data = opened.convert("RGBA").load()
+        for y in range(128):
+            for x in range(128):
+                r, g, b, a = data[x, y]
+                if a <= 16:
+                    continue
+                opaque += 1
+                if (r, g, b) == EYE:
+                    eyes += 1
+    assert opaque and eyes / opaque < 0.01  # the eyes are a sub-1% feature
+
+    pixels = prepare.sampled_reference_pixels(ref)
+    cyan = prepare.parse_hex_color("#00FFFF")
+    cyan_min = min(prepare.color_distance(cyan, pixel) for pixel in pixels)
+    # cyan would win the raw 1st-percentile ranking yet erase the eyes: that is
+    # exactly the trap the guard exists for.
+    assert cyan_min <= prepare.MIN_SUBJECT_KEY_DISTANCE
+
+    result = prepare.choose_chroma_key(ref, "auto")
+    assert result["selection"] == "auto"
+    assert result["name"] != "cyan"
+    # The chosen key clears every subject pixel, including the tiny eyes.
+    assert result["min_subject_distance"] > prepare.MIN_SUBJECT_KEY_DISTANCE
+    assert "warning" not in result
+
+
+def test_auto_key_warns_when_no_candidate_is_safe(tmp_path: Path) -> None:
+    # A subject that parks saturated pixels next to every candidate key: no safe
+    # choice exists, so the selector falls back to the ranking *and* warns.
+    ref = tmp_path / "rainbow.png"
+    image = Image.new("RGBA", (32, 32), (0, 0, 0, 0))
+    pixels = image.load()
+    near_keys = [(235, 30, 235), (30, 235, 30), (30, 235, 235), (20, 80, 235)]
+    for index, color in enumerate(near_keys):
+        for x in range(index * 8, index * 8 + 8):
+            for y in range(32):
+                pixels[x, y] = (*color, 255)
+    image.save(ref)
+
+    result = prepare.choose_chroma_key(ref, "auto")
+    assert result["selection"] == "auto"
+    assert result["min_subject_distance"] <= prepare.MIN_SUBJECT_KEY_DISTANCE
+    assert "warning" in result


### PR DESCRIPTION
## Problem

Extraction silently mangles real subject colors whenever the subject shares a channel with the chroma key. Two independent causes, both hit when generating a red/orange character that also has small green/teal features (eyes, an ear lamp):

### 1. `remove_chroma_background` despill has no distance gate

The third branch ran `neutralize_key_tint` on **any** pixel with a high `key_tint_score`, regardless of how far it was from the key in color space. `neutralize_key_tint` clamps each keyed channel to `min(channel, mean(unkeyed))`. Under a magenta key (two keyed channels: R and B) this drags every saturated warm **and** cool color toward grey/olive — even colors hundreds of units away from magenta.

```
# before, with script defaults (key=#FF00FF, thr=96, fringe=180, delta=18)
crab red body (196, 54, 38) -> (54, 54, 38)   dist=231  DESTROYED
orange shell  (224, 96, 40) -> (96, 96, 40)   dist=237  DESTROYED
blue accent   (40, 70,200)  -> (40, 70, 70)   dist=233  DESTROYED
```

Because branch 2 already turns near-key fringe (`distance <= fringe_threshold and tint >= fringe_delta`) transparent, the neutralize branch **only ever fired on pixels far from the key** — i.e. genuine subject pixels. So it is pure damage. This PR removes the branch (and the now-unused `neutralize_key_tint`); near-key fringe removal is unchanged.

```
# after
crab red body (196, 54, 38) -> (196, 54, 38, 255)   preserved
blue accent   (40, 70,200)  -> (40, 70, 200, 255)   preserved
pure magenta  (255, 0,255)  -> (0, 0, 0, 0)         still removed
```

### 2. `--chroma-key auto` ranks by the 1st-percentile distance, ignoring small features

`choose_chroma_key` scores each candidate by `distances[int(N * 0.01)]` (1st percentile) and picks the max. Any feature that is **under 1% of the subject** (eyes, gems, ear lamps) is discarded as an outlier, so a key can look "safe" while its nearest subject pixel is still inside the extraction erase radius (`--key-threshold`, default 96) and gets deleted.

```
# subject: red body + 0.17% green eyes
AUTO picked -> cyan (#00FFFF), 1st-pctile=353.7  but TRUE-min=77.0 (<=96) -> eyes ERASED
```

`auto` now prefers candidates whose **nearest** subject pixel clears the erase radius, records `min_subject_distance` in the request, and warns on stderr when no candidate clears the subject (so you know to recolor a feature or force a key).

## Changes

- `scripts/extract_sprite_row_frames.py` — drop the global despill branch + `neutralize_key_tint`.
- `scripts/prepare_sprite_run.py` — `choose_chroma_key` feature-safety guard + `min_subject_distance` + warning.
- `tests/test_chroma_extraction.py` — regression coverage for both.
- `SKILL.md` / `CHANGELOG.md` — doc the new behavior.

## Tests

`python3 -m pytest -q` → **11 passed**. The golden extraction manifest is **unchanged**: the removed branch never fired on the green-on-magenta fixture (those pixels are >300 from the key with negative tint), so `test_extraction_golden.py` still matches byte-for-byte.

## Notes / not in scope

A subject with **both** a red body and green features still has no single safe flat key (magenta eats red; green/cyan eat green). The auto guard now surfaces this instead of silently deleting a feature, but a real fix (protected-color list, or transparent/alpha generation) is a larger follow-up. Per-frame bbox centering in `fit_to_cell` (registration drift across animation frames) is likewise left for a separate change.
