### PR TITLE
fix: use POSIX separators in machine-readable manifest paths

### DIFF
--- a/scripts/compose_selected_cycle.py
+++ b/scripts/compose_selected_cycle.py
@@ -153,14 +153,14 @@ def main() -> int:
         "loop": True,
         "note": args.note,
         "outputs": {
-            "gif": str(gif_path.relative_to(run_dir)),
-            "contact": str(contact_path.relative_to(run_dir)),
+            "gif": gif_path.relative_to(run_dir).as_posix(),
+            "contact": contact_path.relative_to(run_dir).as_posix(),
         },
         "source_frames": [
             {
                 "user_frame": user_frame,
                 "zero_based_frame": user_frame - 1,
-                "path": str(path.relative_to(run_dir)),
+                "path": path.relative_to(run_dir).as_posix(),
                 "sha256": sha256(path),
             }
             for user_frame, path in zip(user_frames, frame_paths)

--- a/scripts/extract_sprite_row_frames.py
+++ b/scripts/extract_sprite_row_frames.py
@@ -888,7 +888,7 @@ def main() -> int:
         for index, frame in enumerate(frames):
             output = state_dir / f"frame-{index}.png"
             atomic_save_image(frame, output)
-            output_paths.append(str(output.relative_to(run_dir)))
+            output_paths.append(output.relative_to(run_dir).as_posix())
         # 픽셀퍼펙트 전 원본 변형(.plain.png) — 큐레이션뷰의 전/후 토글과
         # curation.json `pixel_perfect: false` 굽기가 이 쌍둥이를 읽는다.
         plain_paths = []
@@ -896,7 +896,7 @@ def main() -> int:
             for index, frame in enumerate(plain_frames):
                 output = state_dir / f"frame-{index}.plain.png"
                 atomic_save_image(frame, output)
-                plain_paths.append(str(output.relative_to(run_dir)))
+                plain_paths.append(output.relative_to(run_dir).as_posix())
 
         errors, warnings, frame_records = inspect_frames(frames, chroma_key, args)
         all_errors.extend(f"{state}: {error}" for error in errors)

--- a/scripts/unpack_atlas_run.py
+++ b/scripts/unpack_atlas_run.py
@@ -245,7 +245,7 @@ def write_run(
                 framed.alpha_composite(crop, ((cell_w - w) // 2, (cell_h - h) // 2))
             out = state_dir / f"frame-{index}.png"
             atomic_save_image(framed, out)
-            files.append(str(out.relative_to(out_dir)))
+            files.append(out.relative_to(out_dir).as_posix())
         m = meta.get(name, {})
         request_states[name] = {
             "frames": len(state["rects"]),
@@ -319,7 +319,7 @@ def import_png_groups(out_dir: Path, groups: list[dict[str, Any]], iso: dict[str
                 framed.alpha_composite(im, ((cell_w - im.width) // 2, (cell_h - im.height) // 2))
             out = state_dir / f"frame-{index}.png"
             atomic_save_image(framed, out)
-            files.append(str(out.relative_to(out_dir)))
+            files.append(out.relative_to(out_dir).as_posix())
         request_states[state_name] = {"frames": len(imgs), "fps": 2, "loop": False, "action": "imported still set"}
         manifest_rows.append({"state": state_name, "frames": len(imgs), "method": "imported-pngs", "files": files, "labels": labels, "ok": True})
         source_files.extend(p.name for p in group["paths"])


### PR DESCRIPTION
## Problem

On Windows, `str(Path.relative_to(...))` serializes with backslashes, so machine-readable manifests record paths like `frames\\idle\\frame-0.png`:

- `frames/frames-manifest.json` (`rows[].files`, `rows[].plain_files`)
- selected-cycle manifests (`outputs.gif`, `outputs.contact`, `source_frames[].path`)
- unpacked-run `frames-manifest.json` (`rows[].files`)

These manifests are cross-platform contracts (game runtimes, import/porting scripts sample them directly), so separators should not depend on the OS that ran the pipeline. This also breaks `tests/test_extraction_golden.py` on Windows, since the golden manifest expects POSIX paths.

## Fix

Replace `str(...)` with `.as_posix()` at all 7 manifest-serialization sites across `extract_sprite_row_frames.py`, `compose_selected_cycle.py`, and `unpack_atlas_run.py`. No behavior change on POSIX systems.

## Verification

- Before: `test_extraction_matches_golden_manifest` fails on Windows (`frames\\idle\\frame-0.png` vs `frames/idle/frame-0.png`)
- After: full suite passes 15/15 on Windows (CPython 3.11.3)
- Exercised end-to-end on Windows across two full 21-state character runs (extract -> curate -> compose -> runtime consumption of `manifest.json.frame_layout`)