### PR TITLE
fix(frames): align_y 가 픽셀 언페이크 행 경로에서 무시된다

### DIFF
--- a/sprite_gen/frames/extract.py
+++ b/sprite_gen/frames/extract.py
@@ -1860,6 +1860,24 @@ def register_row_frames(frames: list, slack_x: int = 8, slack_y: int = 3) -> lis
     return registered
 
 
+def _content_band(sprite: Image.Image) -> tuple[int, int]:
+    """콘텐츠의 (위, 높이). 빈 이미지는 이미지 전체로 본다."""
+    bbox = sprite.getbbox()
+    if bbox is None:
+        return 0, sprite.height
+    return bbox[1], bbox[3] - bbox[1]
+
+
+def _center_top(sprite: Image.Image, cell_height: int) -> int:
+    """콘텐츠 중심을 셀 세로 한가운데에 두는 top 오프셋.
+
+    바닥 접지(`align_y="bottom"`)와 달리 safe_margin_y 를 빼지 않는다 —
+    가운데 정렬에는 기준선이 없으므로 여백은 위아래로 저절로 갈린다.
+    """
+    content_top, content_height = _content_band(sprite)
+    return round((cell_height - content_height) / 2) - content_top
+
+
 def row_placement(frames: list, cell_width: int, cell_height: int, safe_margin_y: int, scale: int, fit: dict[str, Any]) -> tuple[int, int]:
     # 가로 배치 오프셋은 행 union 기준으로 1회 계산해 전 프레임에 동일 적용한다
     # (플립 대칭·수평 안정). 세로는 place_row_frame 이 프레임별로 접지한다.
@@ -1880,27 +1898,40 @@ def row_placement(frames: list, cell_width: int, cell_height: int, safe_margin_y
         left = (cell_width - sprite.width) // 2
     left = max(0, min(cell_width - sprite.width, left))
     left -= left % scale
+    # align_y "center" 는 접지선이 아니라 콘텐츠 중심을 셀 한가운데 둔다.
+    # 발이 땅에 닿지 않는 피사체(폭발·마법진·투사체)는 바닥에 붙이면 커질수록
+    # 위로 자라서, 재생하면 솟구쳤다 내려온다.
+    if str(fit.get("align_y", "bottom")).lower() == "center":
+        return left, _center_top(sprite, cell_height)
     bbox = sprite.getbbox()
     content_bottom = bbox[3] if bbox else sprite.height
     top = max(0, cell_height - safe_margin_y - content_bottom)
     return left, top
 
 
-def place_row_frame(frame: Image.Image, cell_width: int, cell_height: int, scale: int, left: int, top: int, safe_margin_y: int | None = None, ground: bool = True) -> Image.Image:
+def place_row_frame(frame: Image.Image, cell_width: int, cell_height: int, scale: int, left: int, top: int, safe_margin_y: int | None = None, ground: bool = True, align_y: str = "bottom") -> Image.Image:
     # 2026-07-04 (알렉스): 세로는 프레임마다 콘텐츠 바닥을 공유 기준선에 접지한다 —
     # 행 union 공동 top 만 쓰면 소스 스트립의 상하 요동이 이동으로 남아 프레임 간
     # "무게감"(발밑 높이)이 들쭉해진다. perfectpixel-studio 의 프레임별 알파 가중
     # 정렬과 같은 원리의 세로축 버전. 점프 같은 의도적 오프셋은 fit.ground_frames
     # = false 로 끌 수 있다 (row_placement 의 공동 top 사용).
+    #
+    # align_y="center" 는 그 기준선을 **중심선**으로 바꾼다. ground 의 뜻은 그대로다
+    # — 켜져 있으면 프레임마다, 꺼져 있으면 행 union 한 번. 접지가 프레임마다
+    # 바닥을 맞추듯, 가운데 정렬은 프레임마다 중심을 맞춘다.
     target = Image.new("RGBA", (cell_width, cell_height), (0, 0, 0, 0))
     if frame.getbbox() is None:
         return target
     sprite = frame.resize((frame.width * scale, frame.height * scale), Image.Resampling.NEAREST)
     frame_top = top
-    if ground and safe_margin_y is not None:
-        bbox = sprite.getbbox()
-        content_bottom = bbox[3] if bbox else sprite.height
-        frame_top = max(0, cell_height - safe_margin_y - content_bottom)
+    centered = str(align_y).lower() == "center"
+    if ground and (centered or safe_margin_y is not None):
+        if centered:
+            frame_top = _center_top(sprite, cell_height)
+        else:
+            bbox = sprite.getbbox()
+            content_bottom = bbox[3] if bbox else sprite.height
+            frame_top = max(0, cell_height - safe_margin_y - content_bottom)
     target.alpha_composite(sprite, (left, frame_top))
     return target
 
@@ -3044,11 +3075,12 @@ def _run_locked(args: argparse.Namespace, run_dir: Path):
             # alpha-centroid 는 프레임별 가로 배치 — 행 union 공동 left 로는
             # register_row_frames 의 정합 잔차가 지터로 남는다.
             per_frame_centroid = str(fit_config.get("align_x", "foot-centroid")).lower() == "alpha-centroid"
+            align_y = str(fit_config.get("align_y", "bottom")).lower()
             frames = [
                 place_row_frame(
                     frame, cell_width, cell_height, pp_scale,
                     _alpha_centroid_row_left(frame, cell_width, pp_scale) if per_frame_centroid else left,
-                    top, safe_margin_y, ground_frames)
+                    top, safe_margin_y, ground_frames, align_y)
                 for frame in quantized
             ]
             # 전/후 비교 쌍둥이: 픽셀 언페이크 프레임의 최종 콘텐츠 bbox 와 같은 풋프린트에

--- a/sprite_gen/gen/prepare.py
+++ b/sprite_gen/gen/prepare.py
@@ -1025,7 +1025,8 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--chroma-key", default="auto", help="auto or #RRGGBB")
     parser.add_argument("--fit-resample", choices=["lanczos", "nearest", "kcentroid"], default=None, help="frame downscale filter; nearest keeps pixel-art edges crisp, kcentroid keeps 1px outlines readable")
     parser.add_argument("--fit-align-x", choices=["bbox-center", "centroid", "foot-centroid", "alpha-centroid"], default=None, help="horizontal frame anchor; centroid stabilizes body position across variable-width poses, foot-centroid anchors on the bottom-20%% alpha (legs), alpha-centroid is the perfectpixel-studio per-frame alpha-weighted centroid (fringe-insensitive, per-frame in the pixel unfake row path)")
-    parser.add_argument("--fit-align-y", choices=["center", "bottom"], default=None, help="vertical frame anchor; bottom pins feet to a shared baseline")
+    parser.add_argument("--fit-align-y", choices=["center", "bottom"], default=None, help="vertical frame anchor; bottom pins feet to a shared baseline, center pins the content centre to the cell centre (effects, projectiles, and anything that never touches the ground)")
+    parser.add_argument("--fit-ground-frames", action=argparse.BooleanOptionalAction, default=None, help="re-anchor every frame to the shared vertical line (default on); --no-fit-ground-frames keeps the row-union offset so deliberate vertical travel (jump arcs) survives")
     parser.add_argument("--fit-pixel-unfake", action=argparse.BooleanOptionalAction, default=None, help="unfake the AI dots: pitch detection -> grid snap -> kCentroid -> shared palette -> integer NEAREST (see docs/pixel-unfake.md)")
     # 은퇴한 이름 (조용한 별칭 금지 — 두 이름이 공존하면 문서·스크립트가 갈라진다)
     parser.add_argument("--fit-pixel-perfect", "--no-fit-pixel-perfect", dest="_retired_pp",
@@ -1137,6 +1138,7 @@ def _run(args: argparse.Namespace):
         "resample": args.fit_resample,
         "align_x": args.fit_align_x,
         "align_y": args.fit_align_y,
+        "ground_frames": args.fit_ground_frames,
         "pixel_unfake": args.fit_pixel_unfake,
         "logical_height": args.fit_logical_height,
         "palette_size": args.fit_palette_size,

--- a/tests/frames/test_row_placement_align_y.py
+++ b/tests/frames/test_row_placement_align_y.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+"""align_y "center" in the pixel-unfake row path.
+
+`align_y` was documented and accepted by the CLI, but only `fit_to_cell`
+(the non-pixel-unfake extract path) ever read it. With `--fit-pixel-unfake`
+on, placement goes through `row_placement` / `place_row_frame`, which pinned
+content to the bottom unconditionally — so the option silently did nothing
+in the mode most runs use.
+
+The visible failure: a subject that grows (an explosion, a charge-up) is
+re-grounded every frame, so it climbs upward as it expands instead of
+expanding around a fixed centre.
+
+Defaults must stay bottom-anchored — that contract belongs to characters and
+is pinned bit-for-bit by test_extraction_golden.py.
+"""
+
+from PIL import Image
+
+from sprite_gen.frames.extract import place_row_frame, row_placement
+
+
+def _disc(size: int, canvas: int = 40) -> Image.Image:
+    """Centred square blob of `size` px inside a `canvas` px frame."""
+    frame = Image.new("RGBA", (canvas, canvas), (0, 0, 0, 0))
+    start = (canvas - size) // 2
+    for y in range(start, start + size):
+        for x in range(start, start + size):
+            frame.putpixel((x, y), (255, 160, 40, 255))
+    return frame
+
+
+def _content_centre_y(cell: Image.Image) -> float:
+    bbox = cell.getbbox()
+    assert bbox is not None
+    return (bbox[1] + bbox[3]) / 2
+
+
+GROWING = [_disc(8), _disc(24), _disc(12)]
+
+
+def test_row_placement_defaults_to_bottom() -> None:
+    _, bottom_top = row_placement(GROWING, 64, 64, 2, 1, {})
+    _, explicit = row_placement(GROWING, 64, 64, 2, 1, {"align_y": "bottom"})
+    assert bottom_top == explicit
+
+
+def test_growing_subject_climbs_when_bottom_anchored() -> None:
+    """The bug this option exists to avoid — kept as the contrast case."""
+    left, top = row_placement(GROWING, 64, 64, 2, 1, {})
+    centres = [
+        _content_centre_y(place_row_frame(f, 64, 64, 1, left, top, 2, True, "bottom"))
+        for f in GROWING
+    ]
+    assert max(centres) - min(centres) > 4  # 커질수록 위로 자란다
+
+
+def test_center_holds_the_centre_while_the_subject_grows() -> None:
+    left, top = row_placement(GROWING, 64, 64, 2, 1, {"align_y": "center"})
+    centres = [
+        _content_centre_y(place_row_frame(f, 64, 64, 1, left, top, 2, True, "center"))
+        for f in GROWING
+    ]
+    assert max(centres) - min(centres) <= 1  # 반올림 1px 이내
+    for centre in centres:
+        assert abs(centre - 32) <= 1  # 셀 한가운데
+
+
+def test_center_without_ground_uses_the_shared_row_offset() -> None:
+    """ground=False keeps the row-union offset — same as the bottom path."""
+    left, top = row_placement(GROWING, 64, 64, 2, 1, {"align_y": "center"})
+    placed = [
+        place_row_frame(f, 64, 64, 1, left, top, 2, False, "center") for f in GROWING
+    ]
+    assert all(cell.getbbox() is not None for cell in placed)
+    # 공동 오프셋이므로 프레임의 상대 위치가 그대로 남는다 (접지처럼 균일화하지 않는다)
+    assert len({cell.getbbox()[1] for cell in placed}) > 1
+
+
+def test_empty_frame_stays_empty() -> None:
+    blank = Image.new("RGBA", (40, 40), (0, 0, 0, 0))
+    assert place_row_frame(blank, 64, 64, 1, 0, 0, 2, True, "center").getbbox() is None


### PR DESCRIPTION
`fit.align_y` 는 CLI 가 받아 주고(`--fit-align-y center`) 문서 주석도 있지만, 그 값을 읽는 곳은 `fit_to_cell()` 하나입니다 — `--fit-pixel-unfake` 를 **안 켰을 때**의 경로입니다. 켜면 배치가 `row_placement()` / `place_row_frame()` 로 가는데, 그 둘은 `align_y` 를 아예 참조하지 않고 무조건 바닥에 접지합니다.

배선이 끊긴 흔적이 남아 있습니다 — `frames/extract.py` 의 `fit_pixel_unfake()` 는 `align_y` 를 제대로 읽는데 **패키지 안에서 아무도 부르지 않습니다.** 이 PR 은 실질적으로 그 함수의 세로 정렬 로직을 실제 경로로 옮긴 것입니다.

## 증상

에러가 아니라 그림으로 나옵니다. 커지는 피사체(폭발, 응축하는 기)가 프레임마다 다시 접지돼서, 중심을 두고 퍼지는 대신 **위로 자랍니다.** 재생하면 솟구쳤다 내려옵니다.

실측 (폭발 4프레임, 128² 셀, `--fit-pixel-unfake`):

| | 프레임별 콘텐츠 중심 y |
|---|---|
| 현재 (기본값·`center` 둘 다) | 103 → 91 → 100 — **12px 튐** |
| 이 PR + `--fit-align-y center` | 64 → 64 → 64 — 0px |

발이 땅에 닿지 않는 것들(이펙트·투사체·마법진)에는 접지선 자체가 없으므로, 기준을 중심선으로 바꿀 수 있어야 합니다.

## 바뀌는 것

- `row_placement()` 가 `align_y="center"` 일 때 콘텐츠 중심을 셀 한가운데로 둡니다
- `place_row_frame()` 에 `align_y` 인자 추가 (기본 `"bottom"`). **`ground` 의 뜻은 그대로입니다** — 켜면 프레임마다, 끄면 행 union 한 번. 접지가 프레임마다 바닥을 맞추듯, 가운데 정렬은 프레임마다 중심을 맞춥니다
- `prepare` 에 `--fit-ground-frames/--no-fit-ground-frames`. 코드 주석에 언급된 노브인데 플래그가 없어서 `sprite-request.json` 을 손으로 고쳐야만 닿았습니다

**기본값은 `bottom` 그대로**라 캐릭터 경로는 영향이 없습니다.

## 검증

- 새 테스트 5개 (`tests/frames/test_row_placement_align_y.py`). 그중 하나는 **버그 자체를 고정**합니다 — 바닥 정렬에서 커지는 피사체가 4px 이상 튄다는 것. 회귀하면 그게 먼저 깨집니다
- 기존 테스트: 이 브랜치 `910 passed / 19 failed`, `main` `905 passed / 19 failed`. **실패 19개는 main 에서도 동일**합니다 (`tests/serve/` curation 계열, 이 패치와 무관)
- 실제 런에서 기본값(`bottom`) 추출 결과가 패치 전후로 픽셀 단위 동일함을 확인했습니다

## 맥락

도트 스프라이트 생성 SaaS 에서 `sprite-gen` 을 서브프로세스로 쓰고 있고, 이펙트(폭발·마법) 시트를 만들면서 발견했습니다. 품질 때문에 `--fit-pixel-unfake` 를 항상 켜는데, 그게 곧 세로 정렬 옵션을 잃는다는 뜻이었습니다.