### PR TITLE
docs: restore community contributor attribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable public changes to `sprite-gen` are recorded here. Versions track the
 
 ## v1.59.0 - Contributor Collection
 
-This release collects five community pull requests into one tested release. Thanks to [@Dongkyu-ES](https://github.com/Dongkyu-ES) for deterministic CLI tests, engine export, and subject-aware sparse-frame handling, and to [@napkn34](https://github.com/napkn34) for the Windows provider and publish-lock fixes.
+This release incorporates accepted work from seven community pull requests. Thanks to [@devswha](https://github.com/devswha) for chroma color preservation, [@bokjk](https://github.com/bokjk) for portable manifest paths, [@Dongkyu-ES](https://github.com/Dongkyu-ES) for deterministic CLI tests, engine export, and subject-aware sparse-frame handling, and [@napkn34](https://github.com/napkn34) for the Windows provider and publish-lock fixes.
 
 - Added `sprite-gen export-aseprite` for Phaser-compatible Aseprite JSON and Flame-compatible hash files split by state. Curated frame geometry and timing remain canonical, and exports are confined to the run's `exports/` directory.
 - Added a Windows `LockFileEx` backend that preserves shared readers and exclusive publishers across processes without weakening the fail-loud isolation contract.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,24 @@
+# Contributors
+
+The following external contributors have changes incorporated into the current `sprite-gen` codebase.
+
+## [@devswha](https://github.com/devswha)
+
+- [PR #1](https://github.com/aldegad/sprite-gen/pull/1): protected subject colors during chroma cleanup and improved automatic key selection.
+
+## [@bokjk](https://github.com/bokjk)
+
+- [PR #2](https://github.com/aldegad/sprite-gen/pull/2): made machine-readable manifest paths use portable POSIX separators. The accepted change was ported into the reorganized package implementation.
+
+## [@Dongkyu-ES](https://github.com/Dongkyu-ES)
+
+- [PR #4](https://github.com/aldegad/sprite-gen/pull/4): made CLI help tests deterministic in colored shell environments.
+- [PR #5](https://github.com/aldegad/sprite-gen/pull/5): added Aseprite JSON, Phaser-compatible, and Flame-compatible exports.
+- [PR #6](https://github.com/aldegad/sprite-gen/pull/6): introduced character and effect subject profiles. The accepted implementation uses resolution-aware sparse-frame floors.
+
+## [@napkn34](https://github.com/napkn34)
+
+- [PR #7](https://github.com/aldegad/sprite-gen/pull/7): fixed Windows provider CLI resolution and UTF-8 subprocess I/O.
+- [PR #9](https://github.com/aldegad/sprite-gen/pull/9): added the Windows `LockFileEx` backend for shared readers and exclusive publishers.
+
+Thank you for testing the project in real environments, documenting the failures clearly, and contributing fixes that now ship as part of `sprite-gen`.

--- a/README.md
+++ b/README.md
@@ -246,6 +246,8 @@ contract.
 
 The component-row workflow is inspired by the Apache-2.0 licensed `hatch-pet` skill, but targets generic game sprite atlases and includes no pet packages or pet visual assets.
 
+Accepted community contributions and their originating pull requests are listed in [`CONTRIBUTORS.md`](CONTRIBUTORS.md).
+
 ## License
 
 Apache-2.0

--- a/tests/gen/test_gen.py
+++ b/tests/gen/test_gen.py
@@ -74,6 +74,7 @@ def test_provider_run_uses_scrubbed_env(tmp_path: Path, monkeypatch) -> None:
     # Both providers must route their subprocess.run through the scrubbed env.
     import sprite_gen.gen.grok_provider as grok_provider
 
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
     seen: dict[str, dict | None] = {}
 
     class _Completed:
@@ -130,6 +131,7 @@ def test_provider_run_uses_scrubbed_env(tmp_path: Path, monkeypatch) -> None:
 def test_provider_commands_use_the_single_resolved_binary(tmp_path: Path, monkeypatch) -> None:
     import sprite_gen.gen.grok_provider as grok_provider
 
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
     seen: dict[str, list[str]] = {}
     monkeypatch.setattr(codex_provider, "provider_binary", lambda _name: "C:/bin/codex.CMD")
     monkeypatch.setattr(grok_provider, "provider_binary", lambda _name: "C:/bin/grok.CMD")


### PR DESCRIPTION
## What changed

- Added `CONTRIBUTORS.md` with the four external contributors whose work is present in the current codebase.
- Linked each contributor to the accepted pull requests: #1, #2, #4, #5, #6, #7, and #9.
- Linked the contributor record from the README.
- Added GitHub noreply `Co-authored-by` trailers so the rewritten default-branch history retains commit-level attribution without exposing private email addresses.

## Why

The v1.59.0 privacy cleanup rebuilt the repository as a sanitized single-root history. The accepted code remained, but the original pull request commits were intentionally not connected to the new root. GitHub therefore could not derive the contributor identities from the default branch.

## Verification

- Confirmed the four GitHub accounts and seven accepted PRs against repository metadata.
- Confirmed rejected PR #3 and author-closed PR #11 are not listed as accepted code contributions.
- Confirmed all four noreply identities are present in the non-empty documentation commit.
