### PR TITLE
fix: parse Codex extension image generation results

### DIFF
--- a/sprite_gen/gen/codex_provider.py
+++ b/sprite_gen/gen/codex_provider.py
@@ -27,11 +27,14 @@ from pathlib import Path
 
 from .base import GEN_TIMEOUT_SECONDS, GenRequest, GenTimeoutError, ProviderRun, provider_binary, provider_subprocess_env, verify_png
 
-# codex carries the inline base64 on a version-specific record. Both are
-# first-class canonical records (not a fallback) — read whichever the running
+# codex carries the inline base64 on a version-specific record. All are
+# first-class canonical records (not fallbacks) — read whichever the running
 # codex emits. v0.140.0: response_item `image_generation_call`. v0.144.1:
 # event_msg `image_generation_end` (+status, saved_path — saved_path untrusted).
+# v0.149.1: event_msg `item_completed` wrapping an Extension item with kind
+# `image_gen.generation`.
 _RESULT_TYPES = ("image_generation_call", "image_generation_end")
+_IMAGE_GEN_EXTENSION_KIND = "image_gen.generation"
 # The session id that names the rollout jsonl. v0.144.1 `codex exec --json` emits
 # it as `{"type":"thread.started","thread_id":"<uuid>"}` on stdout; older codex
 # printed a `session id: <uuid>` text line. Both are canonical per version.
@@ -172,6 +175,16 @@ def _collect_inline_results(rollout: Path) -> list[str]:
             except json.JSONDecodeError:
                 continue
             payload = record.get("payload", {}) or {}
+            if payload.get("type") == "item_completed":
+                item = payload.get("item", {}) or {}
+                if (
+                    item.get("type") == "Extension"
+                    and item.get("kind") == _IMAGE_GEN_EXTENSION_KIND
+                    and item.get("status") == "completed"
+                    and item.get("result")
+                ):
+                    results.append(item["result"])
+                continue
             if payload.get("type") not in _RESULT_TYPES or not payload.get("result"):
                 continue
             status = payload.get("status")
@@ -215,7 +228,7 @@ def _no_image_records_message(rollout: Path, codex_home: Path) -> str:
     """
     return (
         "codex-gen: the built-in image_gen tool never ran in this codex session — "
-        f"zero {' / '.join(_RESULT_TYPES)} records in {rollout}\n"
+        f"zero {' / '.join((*_RESULT_TYPES, _IMAGE_GEN_EXTENSION_KIND))} records in {rollout}\n"
         f"  the prompt carries the official {_SKILL_TRIGGER} skill trigger, so the tool was "
         "not offered to the session rather than merely not chosen.\n"
         f"  the account behind this Codex state root ({codex_home}) does not provide the "

--- a/sprite_gen/gen/codex_provider.py
+++ b/sprite_gen/gen/codex_provider.py
@@ -177,13 +177,19 @@ def _collect_inline_results(rollout: Path) -> list[str]:
             payload = record.get("payload", {}) or {}
             if payload.get("type") == "item_completed":
                 item = payload.get("item", {}) or {}
-                if (
-                    item.get("type") == "Extension"
-                    and item.get("kind") == _IMAGE_GEN_EXTENSION_KIND
-                    and item.get("status") == "completed"
-                    and item.get("result")
-                ):
-                    results.append(item["result"])
+                if item.get("type") != "Extension" or item.get("kind") != _IMAGE_GEN_EXTENSION_KIND:
+                    continue
+                status = item.get("status")
+                if status != "completed":
+                    raise SystemExit(
+                        f"codex-gen: image_gen call ended with status={status!r} in {rollout}"
+                    )
+                result = item.get("result")
+                if not result:
+                    raise SystemExit(
+                        f"codex-gen: completed image_gen call has no result in {rollout}"
+                    )
+                results.append(result)
                 continue
             if payload.get("type") not in _RESULT_TYPES or not payload.get("result"):
                 continue

--- a/tests/gen/test_gen.py
+++ b/tests/gen/test_gen.py
@@ -221,17 +221,6 @@ def test_codex_inline_extraction_reads_0149_imagegen_extension(tmp_path: Path) -
                 "item": {
                     "type": "Extension",
                     "kind": "image_gen.generation",
-                    "status": "failed",
-                    "result": b64,
-                },
-            }
-        },
-        {
-            "payload": {
-                "type": "item_completed",
-                "item": {
-                    "type": "Extension",
-                    "kind": "image_gen.generation",
                     "status": "completed",
                     "result": b64,
                 },
@@ -243,6 +232,42 @@ def test_codex_inline_extraction_reads_0149_imagegen_extension(tmp_path: Path) -
     results = codex_provider._collect_inline_results(rollout)
 
     assert results == [b64]
+
+
+@pytest.mark.parametrize(
+    ("status", "result", "expected_message"),
+    [
+        ("failed", "failure details", "status='failed'"),
+        ("completed", None, "completed image_gen call has no result"),
+    ],
+)
+def test_codex_inline_extraction_rejects_failed_or_empty_0149_imagegen_extension(
+    tmp_path: Path,
+    status: str,
+    result: str | None,
+    expected_message: str,
+) -> None:
+    rollout = tmp_path / "rollout-codex-0149-invalid.jsonl"
+    rollout.write_text(
+        json.dumps(
+            {
+                "payload": {
+                    "type": "item_completed",
+                    "item": {
+                        "type": "Extension",
+                        "kind": "image_gen.generation",
+                        "status": status,
+                        "result": result,
+                    },
+                }
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit, match=expected_message):
+        codex_provider._collect_inline_results(rollout)
 
 
 def test_codex_inline_extraction_rejects_failed_status(tmp_path: Path) -> None:

--- a/tests/gen/test_gen.py
+++ b/tests/gen/test_gen.py
@@ -200,6 +200,51 @@ def test_codex_inline_extraction_reads_both_record_types(tmp_path: Path) -> None
     assert gen_base.verify_png(dest) > 0
 
 
+def test_codex_inline_extraction_reads_0149_imagegen_extension(tmp_path: Path) -> None:
+    b64 = base64.b64encode(_png_bytes()).decode()
+    rollout = tmp_path / "rollout-codex-0149.jsonl"
+    lines = [
+        {
+            "payload": {
+                "type": "item_completed",
+                "item": {
+                    "type": "Extension",
+                    "kind": "other.extension",
+                    "status": "completed",
+                    "result": b64,
+                },
+            }
+        },
+        {
+            "payload": {
+                "type": "item_completed",
+                "item": {
+                    "type": "Extension",
+                    "kind": "image_gen.generation",
+                    "status": "failed",
+                    "result": b64,
+                },
+            }
+        },
+        {
+            "payload": {
+                "type": "item_completed",
+                "item": {
+                    "type": "Extension",
+                    "kind": "image_gen.generation",
+                    "status": "completed",
+                    "result": b64,
+                },
+            }
+        },
+    ]
+    rollout.write_text("\n".join(json.dumps(line) for line in lines) + "\n", encoding="utf-8")
+
+    results = codex_provider._collect_inline_results(rollout)
+
+    assert results == [b64]
+
+
 def test_codex_inline_extraction_rejects_failed_status(tmp_path: Path) -> None:
     b64 = base64.b64encode(_png_bytes()).decode()
     rollout = tmp_path / "rollout-fail.jsonl"


### PR DESCRIPTION
Summary:
- Add support for Codex CLI 0.149.1 image generation rollout records emitted as completed Extension/image_gen.generation items.
- Keep support for legacy image_generation_call and image_generation_end result records.
- Add regression coverage for the new rollout schema.

Tests:
- python -m pytest tests/gen/test_gen.py -q
- python -m pytest tests/gen -q

Notes:
This fixes false “image_gen tool never ran” diagnostics when Codex did generate a valid inline PNG under the newer item_completed Extension schema.