### PR TITLE
gen: sprite-gen video — image to video with the user's own Grok credential (v1.61.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable public changes to `sprite-gen` are recorded here. Versions track the `version:` field in `SKILL.md` and `pyproject.toml`.
 
+## v1.61.0 - Image to Video
+
+- Added `sprite-gen video`: one still + prompt → a verified mp4 through Grok Imagine (`POST /v1/videos/generations`), with duration 1–15 s, 480p/720p/1080p, optional aspect ratio and audio flag, and a `sprite-gen-video-report` JSON.
+- Credentials are the user's own and never part of the repo: `XAI_API_KEY` when set, otherwise the `grok` CLI login file (`~/.grok/auth.json`, `GROK_HOME` honoured). The report records `auth_source`; tokens and download URLs are never printed or written.
+- An expired grok login fails before any upload with the exact refresh command; a set-but-empty `XAI_API_KEY`, a missing credential, a refused request, a failed/expired generation, a poll timeout, or a non-mp4 download each fail by name and write nothing.
+- New wrapper `scripts/generate_sprite_video.py` and docs at `docs/video.md`.
+
 ## v1.60.0 - Native Alpha
 
 - `sprite-gen gen --transparent` now follows a per-provider transparency strategy declared once on each adapter (`Provider.transparency`). `codex` asks `image_gen` for a genuinely transparent background and publishes the measured alpha (`native`, first choice); `grok` keeps deterministic chroma keying because Grok Imagine returns JPEG only.

--- a/README.md
+++ b/README.md
@@ -252,6 +252,15 @@ implementation. Transparent stills follow a per-provider strategy: `codex` asks
 is published; `grok` is keyed out of a chroma background. See
 [`docs/gen.md`](docs/gen.md) for the CLI and verification contract.
 
+### Image to video
+
+`sprite-gen video --image still.png --prompt "…" --out clip.mp4` animates one
+still through Grok Imagine using **your own** credential — the `grok` CLI login
+(`grok login`, SuperGrok Imagine quota) or an `XAI_API_KEY`. Nothing is shipped
+with the repo; the report says which one ran. An expired login stops before
+uploading and tells you the exact refresh command. Setup, parameters, and the
+verification contract: [`docs/video.md`](docs/video.md).
+
 ## Attribution
 
 The component-row workflow is inspired by the Apache-2.0 licensed `hatch-pet` skill, but targets generic game sprite atlases and includes no pet packages or pet visual assets.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sprite-gen
-version: 1.60.0
+version: 1.61.0
 description: "Generate clean 2D game sprites and animation atlases with a component-row pipeline: base identity, numeric sprite-request SSoT, per-state layout guides, image-gen row strips, chroma-key alpha cleanup, connected-component frame extraction, cell-based atlas composition, QA reports, and runtime manifest frame_layout. Its curation webview also serves ANY image-candidate set (icons, logos, generated drafts) — agent chat can't render images, this can: unpack_atlas_run --pngs-dir import, then serve_curation side-by-side compare/pick. Palette-swap bake (`sprite-gen recolor`) turns a base sheet + palette map into N colourway sheets; the curation view blink-compares and adopts a pick into curation.json.recolor.picked. Curation triggers (KR/EN): 큐레이션, 큐레이션뷰, 큐레이션 해줘, 이미지 후보 보여줘/안 보임, 나란히 비교, 골라볼게 띄워줘, curation view, show image candidates side by side, let me pick. Recolor triggers (KR/EN): 팔레트 스왑, 팔레트 베이크, 리컬러, 색깔 바꾸기, 컬러웨이, 색 변형, 팔레트 맵, 색갈이, palette swap, recolor, colourway, colorway, bake variants, palette map."
 license: Apache-2.0
 depends_on:
@@ -12,6 +12,7 @@ depends_on:
   required_scripts:
     - scripts/prepare_sprite_run.py
     - scripts/generate_sprite_image.py
+    - scripts/generate_sprite_video.py
     - scripts/extract_sprite_row_frames.py
     - scripts/interpolate_frames.py
     - scripts/compose_sprite_atlas.py
@@ -195,6 +196,7 @@ Scripts are explicit pipeline commands, not hidden imports. One job each (stage 
 - `sprite_gen/compose/compose_layers.py` (`sprite-gen compose-layers`) — deterministic composite bake for a run that declares a **rig**. Stacks curated rows onto each other by integer pivot translation + arbitrary alpha masks (no resampling, rotation or scale of its own) into `<run-dir>/layers/<name>.png` + `<name>.manifest.json` + `layers.report.json`. Optional and opt-in: a request with no `rig` / `track` / `layers` is not a layer run and is refused by name rather than composed. All-or-nothing — declaration, composition **and** publish: one violation reports every violation and writes nothing. Declaration schema, CLI usage, and what `prepare` carries: [`docs/layer-tracks.md`](docs/layer-tracks.md).
 - `unpack_atlas_run.py` — inverse of compose: rebuild a curator-ready run dir from a finished sheet (`--grid` > `--manifest` > auto-detect) or import a PNG folder (`--pngs-dir`, with sibling `meta.json` labels/iso grid).
 - `export_curated_pngs.py` — export curated frames back to named PNGs with the transform baked in, into `<run-dir>/curated/`; the deliverable for imported still sets.
+- `sprite_gen/gen/video.py` (`sprite-gen video`) — one still → verified mp4 through Grok Imagine (`POST /v1/videos/generations`) with the user's own credential: `XAI_API_KEY` if set, else the `grok` CLI login (`~/.grok/auth.json`, SuperGrok Imagine quota). Expired login fails before upload with the refresh command; tokens/URLs never reach the report. The `grok-imagine-video` skill is a thin shuttle over this. Contract: [`docs/video.md`](docs/video.md).
 - `cutout.py` (`sprite-gen cutout`) — background remover for **imported** images (not pipeline output, which is already keyed). Routes on the corner background colour (`--key auto|white|magenta|green`): **white/ivory** → position matte (corner flood-fill keeps interior highlights unholed → decontaminated soft-alpha border + soft erode); **magenta/green key** → reuse the verified `extract.remove_chroma_background` engine as-is (no drift — key colours are absent from objects so its colour-only cut is safe there). `--white-check` writes cyan/magenta/yellow verification composites. No Silent Fallback (leftover non-zero RGB under transparency raises).
 - `slice_sheet_cells.py` — slice a multi-figure grid sheet (same character, N expressions/variants in one image) into per-cell standing cuts: v1.13 chroma alpha + centroid cell assignment + merged-figure split/in-cell re-label + neighbour-debris drop + per-cell height normalization + shared feet baseline. For dialogue cut-in portraits (立ち絵), not animation rows. Detail: [`docs/sheet-slicing.md`](docs/sheet-slicing.md).
 - `check_visible_magenta.py` — optional screenshot QA guard for visible chroma-key leakage.
@@ -505,6 +507,7 @@ sprite-gen (this SKILL.md = behavior contract + hub)
 │
 ├─ GENERATION ── "raw/<state>.png from prompts (the one AI step)"
 │   ├─ docs/gen.md               # sprite-gen gen provider CLI · verified PNG/report · image-gen shuttle
+│   ├─ docs/video.md             # sprite-gen video · Grok Imagine i2v with the user's own grok login / XAI_API_KEY
 │   ├─ docs/frame-interpolation.md  # generative in-between (codex/grok) → take raw · auth prereqs · RIFE retire rationale
 │   └─ docs/seamless-video-loop.md  # non-looping AI video clip → seamless loop: flow-matched cut + RIFE seam bridge
 │

--- a/docs/video.md
+++ b/docs/video.md
@@ -1,0 +1,96 @@
+# `sprite-gen video` — image to video with your own Grok login (engine SSoT)
+
+`sprite-gen video` animates one still into a short mp4 through **Grok Imagine**
+(xAI `POST /v1/videos/generations`). It is the video counterpart of
+[`sprite-gen gen`](gen.md): one call = one still (+ prompt) → one **verified** mp4
+on disk plus a machine-readable report. The `grok-imagine-video` skill is a thin
+shuttle over this command.
+
+No credential is shipped with this repository. You bring your own, in one of two
+forms, and every run reports which one it used.
+
+## Setup — pick one credential
+
+| `auth_source` | What you need | Billing | How to set it up |
+|---|---|---|---|
+| `grok-login` (default) | the `grok` CLI signed in once | your SuperGrok **Imagine quota** (no console spend) | install the grok CLI, run `grok login` (`--oauth` for a browser, `--device-auth` for a headless box). It writes `~/.grok/auth.json`; this tool only reads it. |
+| `XAI_API_KEY` | an xAI console API key | console credit | `export XAI_API_KEY=xai-…` |
+
+Resolution order is fixed: **`XAI_API_KEY` wins when set**, otherwise the grok
+login file (`GROK_HOME` relocates `~/.grok`). Neither is a fallback for the other —
+a set-but-empty `XAI_API_KEY` is an error, and with no key and no login the run
+stops with both setup paths spelled out.
+
+### The login token expires — and this tool does not refresh it
+
+The grok CLI stores an OIDC access token that lasts about six hours
+(2026-09-08 measurement: `expires_at` 10:56Z, refreshed to 18:26Z by the next grok
+command). `sprite-gen video` reads `expires_at` **before uploading anything**; if
+it has passed, the run fails with the refresh prescription instead of gambling on
+a 403 mid-upload:
+
+```
+video: the grok login token expired at 2026-09-08T10:56:34Z (now …); nothing was uploaded.
+  refresh it with any grok CLI command that reaches the API, e.g. `grok -p ok --output-format plain`,
+  or sign in again with `grok login`. This tool never rewrites ~/.grok/auth.json itself.
+```
+
+Why not refresh it here: `auth.json` is the grok CLI's file, the refresh token in
+it may rotate, and a second writer would break the login the user relies on
+everywhere else. The same shape as `sprite-gen gen`'s `codex login status` gate.
+
+### Why the direct API call and not Grok Build's `image_to_video` tool
+
+Grok Build's built-in `image_to_video` tool posts without `output.upload_url`, and
+on Zero-Data-Retention teams the API answers `HTTP 400 — Zero Data Retention teams
+must provide output.upload_url for video generation`. The same login calling
+`/v1/videos/generations` directly (no `output.upload_url`) succeeds and bills the
+Imagine quota (verified 2026-08-22, re-verified 2026-09-08). So this engine calls
+the API itself and never routes through the agent-side tool.
+
+## CLI
+
+```bash
+sprite-gen video \
+  --image still.png \                # PNG / JPEG / WebP; sent inline as a data URL
+  --prompt "Camera locked. Gentle idle sway, tail flick." \   # or --prompt-file
+  --out clip.mp4 \
+  [--duration 6]                     # 1..15 seconds (default 6)
+  [--resolution 720p]                # 480p | 720p | 1080p (default 720p)
+  [--aspect-ratio 1:1]               # 1:1 16:9 9:16 4:3 3:4 3:2 2:3 (default: the still's ratio)
+  [--audio | --no-audio]             # default: the API's default (audio on)
+  [--model grok-imagine-video-1.5]
+  [--report clip.report.json]
+```
+
+Backward-compatible wrapper: `$SPRITE_GEN_ROOT/.venv/bin/python $SPRITE_GEN_ROOT/scripts/generate_sprite_video.py …` (same args).
+
+What happens, in order:
+
+1. Validate the request (prompt, still, duration, resolution, aspect ratio) and
+   resolve the credential — all before any network call.
+2. `POST /v1/videos/generations` with `model`, `prompt`, `duration`, `resolution`,
+   optional `aspect_ratio` / `generate_audio`, and `image.url` as a base64 data URL.
+   A `401/403` names the credential source and its fix; any reply without a
+   `request_id` fails with the API's own error text.
+3. `GET /v1/videos/{request_id}` every 4 s until `status` is `done`. `failed`,
+   `expired`, a non-2xx poll, or the timeout (`SPRITE_GEN_VIDEO_TIMEOUT_SECONDS`,
+   default 600) fail loudly. Nothing is written on any failure path.
+4. Download `video.url`, verify the bytes start with an mp4 `ftyp` box, then move
+   the file into `--out` atomically (`.part` staging).
+
+The report (`sprite-gen-video-report`) carries `auth_source`, `model`,
+`request_id`, `bytes`, `host`, requested/reported duration, resolution, aspect
+ratio, audio flag, `elapsed_seconds`, and `polls`. **Tokens and download URLs are
+never printed or written** — only the download host (`vidgen.x.ai`).
+
+## Quotas and limits
+
+- Imagine quota is a weekly SuperGrok allowance; when it is exhausted the API
+  refuses the POST and the run fails with that message (no retry loop here).
+- Duration 1–15 s, resolutions 480p/720p/1080p, the seven aspect ratios above —
+  from the xAI video docs as of 2026-09-08. A value outside those is rejected
+  locally before the call.
+- Output is whatever the model returns (typically H.264 mp4 with audio unless
+  `--no-audio`). Downstream frame extraction is a separate step and not part of
+  this command.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ build-backend = "setuptools.build_meta"
 name = "sprite-gen"
 # Release discipline: keep this package metadata version synchronized with
 # SKILL.md's `version:` field in the same release commit.
-version = "1.60.0"
+version = "1.61.0"
 description = "Component-row pipeline for clean 2D game sprites and animation atlases"
 readme = "README.md"
 license = "Apache-2.0"

--- a/scripts/generate_sprite_video.py
+++ b/scripts/generate_sprite_video.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Backward-compatible wrapper for sprite_gen.gen.video (`sprite-gen video`)."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import sprite_gen.gen.video as _impl
+
+globals().update({name: value for name, value in vars(_impl).items() if name not in {"__name__", "__package__", "__loader__", "__spec__"}})
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sprite_gen/_modules.py
+++ b/sprite_gen/_modules.py
@@ -11,6 +11,7 @@ MODULE_DOMAIN = {
     'migrate_request': 'spec',
     'migrate_breathe': 'spec',
     'generate_image': 'gen',
+    'video': 'gen',
     'prepare': 'gen',
     'extract': 'frames',
     'cutout': 'frames',

--- a/sprite_gen/cli.py
+++ b/sprite_gen/cli.py
@@ -12,7 +12,7 @@ from sprite_gen.curate import anchor
 from sprite_gen.compose import compose_atlas, compose_cycle, compose_gif, compose_layers, export_aseprite, export_pngs
 from sprite_gen.qa import correction_loop, inspect, preview, score
 from sprite_gen.frames import cutout, extract, slice_sheet, unpack_atlas
-from sprite_gen.gen import prepare
+from sprite_gen.gen import prepare, video
 from sprite_gen.effects import recolor
 from sprite_gen.serve import serve_compose, serve_curation
 from sprite_gen.spec import migrate_breathe, migrate_request
@@ -204,6 +204,10 @@ def _add_cutout(p: argparse.ArgumentParser) -> None:
     cutout.add_arguments(p)
 
 
+def _add_video(p: argparse.ArgumentParser) -> None:
+    video.add_arguments(p)
+
+
 def _add_anchor(p: argparse.ArgumentParser) -> None:
     anchor.add_arguments(p)
 
@@ -284,6 +288,11 @@ COMMANDS: dict[str, tuple[str, Callable[[argparse.ArgumentParser], None], Callab
         "Cut a uniform (white/ivory/solid) background off an imported image into a clean transparent PNG.",
         _add_cutout,
         cutout.run,
+    ),
+    "video": (
+        "Animate one still into a verified mp4 via Grok Imagine (your own grok login or XAI_API_KEY).",
+        _add_video,
+        video.run,
     ),
     # The argument surface is `serve_curation.add_arguments` itself, not a copy of it: the
     # webview's own `--help` and this subcommand are the same declaration, so `sprite-gen

--- a/sprite_gen/gen/video.py
+++ b/sprite_gen/gen/video.py
@@ -1,0 +1,453 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Image-to-video through Grok Imagine (xAI `POST /v1/videos/generations`).
+
+One call = one still (+ prompt) -> one verified mp4 on disk. This is the engine
+module behind `sprite-gen video`; the general `grok-imagine-video` skill is a thin
+shuttle over this command.
+
+Credentials are the user's own and never live in this repository. Two sources,
+resolved in a fixed order and always reported (`auth_source`):
+
+1. `XAI_API_KEY` - an xAI console key (the explicit, environment-level choice).
+2. the grok CLI login file `~/.grok/auth.json` (SuperGrok Imagine quota via the
+   OIDC access token the CLI stored at `grok login`). `GROK_HOME` relocates it.
+
+The login token expires (about six hours, 2026-09-08 실측) and the grok CLI is the
+only writer of that file, so an expired token is not refreshed here: the run
+stops before uploading anything and says exactly which command refreshes it.
+No silent fallback between the two sources, no retry with a different tool
+(Grok Build's built-in `image_to_video` is a separate client that returns
+HTTP 400 on Zero-Data-Retention teams; this direct call is what works).
+
+Truth is the mp4 bytes on disk (`ftyp` box verified), never the API's status
+string. Tokens and download URLs are never printed or written to the report.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import mimetypes
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+from sprite_gen.spec.runio import atomic_write_text
+
+API_BASE = "https://api.x.ai/v1"
+DEFAULT_MODEL = "grok-imagine-video-1.5"
+RESOLUTIONS = ("480p", "720p", "1080p")
+ASPECT_RATIOS = ("1:1", "16:9", "9:16", "4:3", "3:4", "3:2", "2:3")
+DURATION_MIN, DURATION_MAX = 1, 15
+AUTH_ENV = "XAI_API_KEY"
+AUTH_SOURCE_API_KEY = "XAI_API_KEY"
+AUTH_SOURCE_GROK_LOGIN = "grok-login"
+POLL_INTERVAL_SECONDS = 4.0
+POLL_TIMEOUT_SECONDS = int(os.environ.get("SPRITE_GEN_VIDEO_TIMEOUT_SECONDS", "600"))
+HTTP_TIMEOUT_SECONDS = 120
+# Every mp4/mov starts with a size-prefixed `ftyp` box: bytes 4..8 spell it.
+MP4_FTYP_OFFSET = 4
+MP4_FTYP = b"ftyp"
+_DONE_STATUSES = ("done", "complete", "completed")
+_FAILED_STATUSES = ("failed", "error", "expired")
+
+# The refresh instruction for an expired login. The grok CLI rewrites the token
+# the next time it talks to the API — measured 2026-09-08 with a one-line prompt
+# (`grok -p ok`): expires_at moved from 10:56Z to 18:26Z. `grok login` is the
+# full re-sign-in for a revoked or missing login.
+GROK_REFRESH_COMMAND = "grok -p ok --output-format plain"
+GROK_LOGIN_COMMAND = "grok login"
+
+
+def grok_home() -> Path:
+    configured = os.environ.get("GROK_HOME")
+    if configured is None:
+        return Path.home() / ".grok"
+    if not configured.strip():
+        raise SystemExit("video: GROK_HOME is set but empty; refusing to guess the grok home")
+    return Path(configured).expanduser().resolve()
+
+
+@dataclass(frozen=True)
+class Credential:
+    token: str
+    source: str  # AUTH_SOURCE_API_KEY | AUTH_SOURCE_GROK_LOGIN
+    expires_at: str | None = None
+
+
+def _parse_expiry(raw: str) -> datetime:
+    text = raw.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    parsed = datetime.fromisoformat(text)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _load_grok_login(auth_path: Path, *, now: datetime) -> Credential:
+    if not auth_path.is_file():
+        raise SystemExit(
+            f"video: no xAI credential — {AUTH_ENV} is not set and there is no grok login at "
+            f"{auth_path}.\n"
+            f"  either sign in once with `{GROK_LOGIN_COMMAND}` (SuperGrok Imagine quota, no API key), "
+            f"or export {AUTH_ENV}=<your xAI console key>."
+        )
+    try:
+        auth = json.loads(auth_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SystemExit(f"video: cannot read grok login file {auth_path}: {exc}") from exc
+    entries = [entry for entry in (auth.values() if isinstance(auth, dict) else []) if isinstance(entry, dict)]
+    if len(entries) != 1:
+        raise SystemExit(
+            f"video: grok login file {auth_path} holds {len(entries)} account entr"
+            f"{'y' if len(entries) == 1 else 'ies'}; expected exactly one — refusing to pick one silently. "
+            f"Run `{GROK_LOGIN_COMMAND}` to reset it."
+        )
+    entry = entries[0]
+    token = entry.get("key")
+    if not isinstance(token, str) or not token.strip():
+        raise SystemExit(f"video: grok login file {auth_path} has no access token; run `{GROK_LOGIN_COMMAND}`.")
+    expires_at = entry.get("expires_at")
+    if isinstance(expires_at, str) and expires_at.strip():
+        try:
+            expiry = _parse_expiry(expires_at)
+        except ValueError as exc:
+            raise SystemExit(f"video: grok login file {auth_path} has an unreadable expires_at {expires_at!r}: {exc}") from exc
+        if expiry <= now:
+            raise SystemExit(
+                f"video: the grok login token expired at {expires_at} (now {now.isoformat()}); nothing was uploaded.\n"
+                f"  refresh it with any grok CLI command that reaches the API, e.g. `{GROK_REFRESH_COMMAND}`, "
+                f"or sign in again with `{GROK_LOGIN_COMMAND}`. This tool never rewrites {auth_path} itself."
+            )
+    return Credential(token=token, source=AUTH_SOURCE_GROK_LOGIN, expires_at=expires_at if isinstance(expires_at, str) else None)
+
+
+def resolve_credential(*, env: dict[str, str] | None = None, now: datetime | None = None) -> Credential:
+    """Pick the credential in the fixed order: XAI_API_KEY, then the grok login file."""
+    env = os.environ if env is None else env
+    now = now or datetime.now(timezone.utc)
+    api_key = (env.get(AUTH_ENV) or "").strip()
+    if api_key:
+        return Credential(token=api_key, source=AUTH_SOURCE_API_KEY)
+    if AUTH_ENV in env and not api_key:
+        raise SystemExit(f"video: {AUTH_ENV} is set but empty; unset it to use the grok login, or give it a value")
+    return _load_grok_login(grok_home() / "auth.json", now=now)
+
+
+HttpCall = Callable[[str, str, str, dict | None], tuple[int, Any]]
+
+
+def http_json(method: str, url: str, token: str, body: dict | None = None) -> tuple[int, Any]:
+    data = None if body is None else json.dumps(body).encode("utf-8")
+    request = urllib.request.Request(url, data=data, method=method)
+    request.add_header("Authorization", f"Bearer {token}")
+    request.add_header("Accept", "application/json")
+    if body is not None:
+        request.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
+            raw = response.read().decode("utf-8")
+            return response.status, (json.loads(raw) if raw else {})
+    except urllib.error.HTTPError as exc:
+        raw = exc.read().decode("utf-8", "replace")
+        try:
+            return exc.code, json.loads(raw)
+        except json.JSONDecodeError:
+            return exc.code, {"raw": raw[:400]}
+    except urllib.error.URLError as exc:
+        raise SystemExit(f"video: cannot reach {url}: {exc.reason}") from exc
+
+
+def http_download(url: str, token: str) -> bytes:
+    request = urllib.request.Request(url)
+    try:
+        with urllib.request.urlopen(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
+            return response.read()
+    except urllib.error.HTTPError as first:
+        if first.code not in (401, 403):
+            raise SystemExit(f"video: download failed with HTTP {first.code}") from first
+        request.add_header("Authorization", f"Bearer {token}")
+        try:
+            with urllib.request.urlopen(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
+                return response.read()
+        except urllib.error.HTTPError as second:
+            raise SystemExit(f"video: download failed with HTTP {second.code} even with the bearer token") from second
+    except urllib.error.URLError as exc:
+        raise SystemExit(f"video: cannot download the clip: {exc.reason}") from exc
+
+
+def _data_url(path: Path) -> str:
+    mime = mimetypes.guess_type(path.name)[0] or "image/png"
+    return f"data:{mime};base64," + base64.b64encode(path.read_bytes()).decode("ascii")
+
+
+def _error_detail(body: Any) -> str:
+    if not isinstance(body, dict):
+        return str(body)[:300]
+    parts = [f"{key}={body[key]!r}" for key in ("code", "error", "message", "status", "raw") if body.get(key)]
+    return ", ".join(parts) if parts else json.dumps(body)[:300]
+
+
+def _redact_host(url: str) -> str | None:
+    if not url.startswith("http"):
+        return None
+    parts = url.split("/")
+    return parts[2] if len(parts) > 2 else None
+
+
+def verify_mp4(data: bytes) -> None:
+    if len(data) < MP4_FTYP_OFFSET + len(MP4_FTYP) or data[MP4_FTYP_OFFSET : MP4_FTYP_OFFSET + len(MP4_FTYP)] != MP4_FTYP:
+        raise SystemExit(
+            f"video: downloaded {len(data)} bytes but they are not an mp4 (no ftyp box) — refusing to publish"
+        )
+
+
+@dataclass
+class VideoRequest:
+    image: Path
+    prompt: str
+    out: Path
+    duration: int = 6
+    resolution: str = "720p"
+    aspect_ratio: str | None = None
+    model: str = DEFAULT_MODEL
+    generate_audio: bool | None = None  # None = API default
+
+
+@dataclass
+class VideoResult:
+    out: Path
+    bytes: int
+    model: str
+    request_id: str
+    auth_source: str
+    elapsed_seconds: float
+    polls: int
+    duration_requested: int
+    duration_reported: float | None = None
+    host: str | None = None
+    image: Path | None = None
+    prompt: str = ""
+    resolution: str = ""
+    aspect_ratio: str | None = None
+    generate_audio: bool | None = None
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kind": "sprite-gen-video-report",
+            "provider": "grok-imagine",
+            "auth_source": self.auth_source,
+            "model": self.model,
+            "request_id": self.request_id,
+            "image": str(self.image) if self.image else None,
+            "prompt": self.prompt,
+            "out": str(self.out),
+            "bytes": self.bytes,
+            "host": self.host,
+            "duration_requested": self.duration_requested,
+            "duration_reported": self.duration_reported,
+            "resolution": self.resolution,
+            "aspect_ratio": self.aspect_ratio,
+            "generate_audio": self.generate_audio,
+            "elapsed_seconds": round(self.elapsed_seconds, 3),
+            "polls": self.polls,
+            **({"extra": self.extra} if self.extra else {}),
+        }
+
+
+def _validate(request: VideoRequest) -> None:
+    if not request.prompt.strip():
+        raise SystemExit("video: empty prompt; pass --prompt or --prompt-file")
+    if not request.image.is_file():
+        raise SystemExit(f"video: still image not found: {request.image}")
+    if not (DURATION_MIN <= request.duration <= DURATION_MAX):
+        raise SystemExit(f"video: --duration must be {DURATION_MIN}..{DURATION_MAX} seconds, got {request.duration}")
+    if request.resolution not in RESOLUTIONS:
+        raise SystemExit(f"video: --resolution must be one of {', '.join(RESOLUTIONS)}, got {request.resolution!r}")
+    if request.aspect_ratio is not None and request.aspect_ratio not in ASPECT_RATIOS:
+        raise SystemExit(f"video: --aspect-ratio must be one of {', '.join(ASPECT_RATIOS)}, got {request.aspect_ratio!r}")
+
+
+def generate_video(
+    request: VideoRequest,
+    *,
+    credential: Credential | None = None,
+    call: HttpCall | None = None,
+    download: Callable[[str, str], bytes] | None = None,
+    sleep: Callable[[float], None] | None = None,
+    poll_timeout: float | None = None,
+) -> VideoResult:
+    """Generate one clip and return a VideoResult. Raises SystemExit on any failure."""
+    # Late-bound so a test that monkeypatches the module-level transport never
+    # reaches the network through a default captured at definition time.
+    call = call or http_json
+    download = download or http_download
+    sleep = sleep or time.sleep
+    _validate(request)
+    credential = credential or resolve_credential()
+    out = request.out.expanduser().resolve()
+    image = request.image.expanduser().resolve()
+
+    body: dict[str, Any] = {
+        "model": request.model,
+        "prompt": request.prompt,
+        "duration": request.duration,
+        "resolution": request.resolution,
+        "image": {"url": _data_url(image)},
+    }
+    if request.aspect_ratio:
+        body["aspect_ratio"] = request.aspect_ratio
+    if request.generate_audio is not None:
+        body["generate_audio"] = request.generate_audio
+
+    started = time.monotonic()
+    status, reply = call("POST", f"{API_BASE}/videos/generations", credential.token, body)
+    if status in (401, 403):
+        raise SystemExit(
+            f"video: xAI rejected the credential ({credential.source}) with HTTP {status}: {_error_detail(reply)}\n"
+            + (
+                f"  the grok login token may have been revoked or rotated — run `{GROK_REFRESH_COMMAND}` or `{GROK_LOGIN_COMMAND}`."
+                if credential.source == AUTH_SOURCE_GROK_LOGIN
+                else f"  check the {AUTH_ENV} value."
+            )
+        )
+    request_id = reply.get("request_id") if isinstance(reply, dict) else None
+    if status not in (200, 202) or not request_id:
+        raise SystemExit(f"video: generation request refused (HTTP {status}): {_error_detail(reply)}")
+
+    deadline = time.monotonic() + (POLL_TIMEOUT_SECONDS if poll_timeout is None else poll_timeout)
+    polls = 0
+    video_url: str | None = None
+    duration_reported: float | None = None
+    model_reported: str | None = None
+    while True:
+        polls += 1
+        http, poll = call("GET", f"{API_BASE}/videos/{request_id}", credential.token, None)
+        poll_status = poll.get("status") if isinstance(poll, dict) else None
+        if http in (200, 202) and poll_status in _DONE_STATUSES:
+            video = poll.get("video") or {}
+            video_url = video.get("url") if isinstance(video, dict) else None
+            duration_reported = video.get("duration") if isinstance(video, dict) else None
+            model_reported = poll.get("model")
+            break
+        if http not in (200, 202) or poll_status in _FAILED_STATUSES:
+            raise SystemExit(
+                f"video: generation {request_id} ended with status={poll_status!r} (HTTP {http}): {_error_detail(poll)}"
+            )
+        if time.monotonic() >= deadline:
+            raise SystemExit(
+                f"video: generation {request_id} still {poll_status!r} after {polls} polls — poll timeout; "
+                "nothing was written"
+            )
+        sleep(POLL_INTERVAL_SECONDS)
+
+    if not video_url:
+        raise SystemExit(f"video: generation {request_id} is done but reported no video url")
+    data = download(video_url, credential.token)
+    verify_mp4(data)
+    elapsed = time.monotonic() - started
+
+    out.parent.mkdir(parents=True, exist_ok=True)
+    tmp = out.with_name(out.name + ".part")
+    tmp.write_bytes(data)
+    os.replace(tmp, out)
+
+    return VideoResult(
+        out=out,
+        bytes=len(data),
+        model=model_reported or request.model,
+        request_id=str(request_id),
+        auth_source=credential.source,
+        elapsed_seconds=elapsed,
+        polls=polls,
+        duration_requested=request.duration,
+        duration_reported=duration_reported,
+        host=_redact_host(video_url),
+        image=image,
+        prompt=request.prompt,
+        resolution=request.resolution,
+        aspect_ratio=request.aspect_ratio,
+        generate_audio=request.generate_audio,
+    )
+
+
+def _print_json(payload: dict) -> None:
+    text = json.dumps(payload, ensure_ascii=False, indent=2) + "\n"
+    buffer = getattr(sys.stdout, "buffer", None)
+    if buffer is not None:
+        buffer.write(text.encode("utf-8"))
+        buffer.flush()
+    else:
+        sys.stdout.write(text)
+
+
+def add_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--image", required=True, type=Path, help="the still to animate (PNG/JPEG/WebP)")
+    parser.add_argument("--prompt")
+    parser.add_argument("--prompt-file", type=Path)
+    parser.add_argument("--out", required=True, type=Path, help="destination .mp4")
+    parser.add_argument("--duration", type=int, default=6, help=f"seconds, {DURATION_MIN}..{DURATION_MAX} (default 6)")
+    parser.add_argument("--resolution", choices=RESOLUTIONS, default="720p")
+    parser.add_argument("--aspect-ratio", choices=ASPECT_RATIOS, default=None, help="default: the still's own ratio")
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    audio = parser.add_mutually_exclusive_group()
+    audio.add_argument("--audio", dest="generate_audio", action="store_true", default=None, help="ask for generated audio")
+    audio.add_argument("--no-audio", dest="generate_audio", action="store_false", help="silent clip")
+    parser.add_argument("--report", type=Path, help="write the sprite-gen-video-report JSON here")
+
+
+def _run(args: argparse.Namespace) -> int:
+    prompt = args.prompt
+    if args.prompt_file:
+        prompt = Path(args.prompt_file).expanduser().read_text(encoding="utf-8")
+    request = VideoRequest(
+        image=args.image,
+        prompt=(prompt or "").strip(),
+        out=args.out,
+        duration=args.duration,
+        resolution=args.resolution,
+        aspect_ratio=args.aspect_ratio,
+        model=args.model,
+        generate_audio=args.generate_audio,
+    )
+    result = generate_video(request)
+    payload = result.to_dict()
+    if args.report:
+        report_path = Path(args.report).expanduser().resolve()
+        atomic_write_text(report_path, json.dumps(payload, ensure_ascii=False, indent=2) + "\n")
+        payload["report"] = str(report_path)
+    _print_json(payload)
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="sprite-gen video", description=__doc__)
+    add_arguments(parser)
+    return parser
+
+
+def run(**kwargs: object) -> int:
+    parser = _build_parser()
+    known = {action.dest for action in parser._actions if action.dest != "help"}
+    unexpected = set(kwargs) - known
+    if unexpected:
+        raise TypeError(f"unexpected keyword argument(s): {', '.join(sorted(unexpected))}")
+    namespace = argparse.Namespace(**{dest: kwargs.get(dest, parser.get_default(dest)) for dest in known})
+    return _run(namespace)
+
+
+def main(argv: list[str] | None = None) -> int:
+    return _run(_build_parser().parse_args(argv))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/gen/test_video.py
+++ b/tests/gen/test_video.py
@@ -1,0 +1,271 @@
+# SPDX-License-Identifier: Apache-2.0
+"""`sprite-gen video` contract: credential resolution, the api.x.ai call shape,
+verified mp4 publishing, and loud failures. No network — the HTTP layer is a fake."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from sprite_gen.gen import video
+
+NOW = datetime(2026, 9, 8, 12, 0, tzinfo=timezone.utc)
+MP4 = b"\x00\x00\x00\x18ftypisom" + b"\x00" * 64
+
+
+def _still(tmp_path: Path) -> Path:
+    path = tmp_path / "still.png"
+    Image.new("RGBA", (8, 8), (255, 120, 0, 255)).save(path)
+    return path
+
+
+def _login_file(tmp_path: Path, *, expires_at: str | None = "2026-09-08T18:00:00.000000Z", key: str = "tok") -> Path:
+    home = tmp_path / "grokhome"
+    home.mkdir(exist_ok=True)
+    entry = {"key": key, "auth_mode": "oidc"}
+    if expires_at is not None:
+        entry["expires_at"] = expires_at
+    (home / "auth.json").write_text(json.dumps({"https://auth.x.ai::client": entry}), encoding="utf-8")
+    return home
+
+
+class _FakeApi:
+    """Scripted xAI: one POST reply, then a sequence of poll replies."""
+
+    def __init__(self, post=(200, {"request_id": "req-1"}), polls=None):
+        self.post = post
+        self.polls = list(polls or [(200, {"status": "done", "video": {"url": "https://vidgen.x.ai/v/1.mp4", "duration": 6.0}, "model": "grok-imagine-video-1.5"})])
+        self.calls: list[tuple[str, str, str, dict | None]] = []
+        self.downloads: list[str] = []
+        self.payload = MP4
+
+    def call(self, method, url, token, body):
+        self.calls.append((method, url, token, body))
+        if method == "POST":
+            return self.post
+        return self.polls.pop(0) if len(self.polls) > 1 else self.polls[0]
+
+    def download(self, url, token):
+        self.downloads.append(url)
+        return self.payload
+
+
+def _request(tmp_path: Path, **overrides) -> video.VideoRequest:
+    kwargs = dict(image=_still(tmp_path), prompt="camera locked, gentle idle sway", out=tmp_path / "clip.mp4")
+    kwargs.update(overrides)
+    return video.VideoRequest(**kwargs)
+
+
+# --- credential resolution -------------------------------------------------
+
+
+def test_api_key_env_wins_over_grok_login(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("GROK_HOME", str(_login_file(tmp_path)))
+    cred = video.resolve_credential(env={"XAI_API_KEY": "xai-console"}, now=NOW)
+    assert cred == video.Credential(token="xai-console", source=video.AUTH_SOURCE_API_KEY)
+
+
+def test_grok_login_is_used_when_no_api_key(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("GROK_HOME", str(_login_file(tmp_path, key="oidc-token")))
+    cred = video.resolve_credential(env={}, now=NOW)
+    assert cred.source == video.AUTH_SOURCE_GROK_LOGIN
+    assert cred.token == "oidc-token"
+    assert cred.expires_at == "2026-09-08T18:00:00.000000Z"
+
+
+def test_expired_grok_login_fails_before_upload_with_refresh_prescription(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("GROK_HOME", str(_login_file(tmp_path, expires_at="2026-09-08T10:56:34.899829Z")))
+    with pytest.raises(SystemExit, match="expired at 2026-09-08T10:56:34") as excinfo:
+        video.resolve_credential(env={}, now=NOW)
+    message = str(excinfo.value)
+    assert video.GROK_REFRESH_COMMAND in message
+    assert video.GROK_LOGIN_COMMAND in message
+    assert "never rewrites" in message
+
+
+def test_missing_login_and_key_prescribes_both_setups(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("GROK_HOME", str(tmp_path / "nowhere"))
+    with pytest.raises(SystemExit, match="no xAI credential") as excinfo:
+        video.resolve_credential(env={}, now=NOW)
+    assert "grok login" in str(excinfo.value) and "XAI_API_KEY" in str(excinfo.value)
+
+
+def test_empty_api_key_env_is_refused_not_ignored(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("GROK_HOME", str(_login_file(tmp_path)))
+    with pytest.raises(SystemExit, match="XAI_API_KEY is set but empty"):
+        video.resolve_credential(env={"XAI_API_KEY": "  "}, now=NOW)
+
+
+def test_login_file_with_two_accounts_is_refused(tmp_path: Path, monkeypatch) -> None:
+    home = _login_file(tmp_path)
+    (home / "auth.json").write_text(json.dumps({"a": {"key": "1"}, "b": {"key": "2"}}), encoding="utf-8")
+    monkeypatch.setenv("GROK_HOME", str(home))
+    with pytest.raises(SystemExit, match="holds 2 account entries"):
+        video.resolve_credential(env={}, now=NOW)
+
+
+def test_login_without_expiry_is_accepted(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("GROK_HOME", str(_login_file(tmp_path, expires_at=None)))
+    assert video.resolve_credential(env={}, now=NOW).expires_at is None
+
+
+# --- generation ------------------------------------------------------------
+
+
+def test_generate_video_posts_data_url_polls_and_publishes_verified_mp4(tmp_path: Path) -> None:
+    api = _FakeApi(polls=[(200, {"status": "pending", "progress": 10}), (200, {"status": "done", "video": {"url": "https://vidgen.x.ai/v/1.mp4", "duration": 6.0}, "model": "grok-imagine-video-1.5"})])
+    slept: list[float] = []
+    cred = video.Credential(token="tok", source=video.AUTH_SOURCE_GROK_LOGIN)
+
+    result = video.generate_video(
+        _request(tmp_path, aspect_ratio="1:1", generate_audio=False),
+        credential=cred, call=api.call, download=api.download, sleep=slept.append,
+    )
+
+    method, url, token, body = api.calls[0]
+    assert (method, url, token) == ("POST", f"{video.API_BASE}/videos/generations", "tok")
+    assert body["model"] == video.DEFAULT_MODEL
+    assert body["duration"] == 6 and body["resolution"] == "720p" and body["aspect_ratio"] == "1:1"
+    assert body["generate_audio"] is False
+    assert body["image"]["url"].startswith("data:image/png;base64,")
+    assert "output" not in body  # no upload_url: the direct call is what works on ZDR teams
+    assert api.calls[1][:2] == ("GET", f"{video.API_BASE}/videos/req-1")
+    assert slept == [video.POLL_INTERVAL_SECONDS]
+    assert api.downloads == ["https://vidgen.x.ai/v/1.mp4"]
+    assert result.out.read_bytes() == MP4
+    assert not result.out.with_name("clip.mp4.part").exists()
+    payload = result.to_dict()
+    assert payload["kind"] == "sprite-gen-video-report"
+    assert payload["auth_source"] == "grok-login"
+    assert payload["request_id"] == "req-1"
+    assert payload["host"] == "vidgen.x.ai"
+    assert payload["duration_reported"] == 6.0 and payload["duration_requested"] == 6
+    assert payload["polls"] == 2
+    # Secrets never reach the report: no token, no full download URL.
+    dumped = json.dumps(payload)
+    assert "tok" not in dumped.replace("token", "") and "vidgen.x.ai/v/1.mp4" not in dumped
+
+
+def test_audio_default_is_left_to_the_api(tmp_path: Path) -> None:
+    api = _FakeApi()
+    video.generate_video(_request(tmp_path), credential=video.Credential("t", "XAI_API_KEY"), call=api.call, download=api.download, sleep=lambda s: None)
+    assert "generate_audio" not in api.calls[0][3] and "aspect_ratio" not in api.calls[0][3]
+
+
+@pytest.mark.parametrize(
+    ("post", "polls", "expected"),
+    [
+        ((200, {"error": "quota"}), None, "generation request refused"),
+        ((400, {"code": "invalid-argument", "error": "Zero Data Retention teams must provide output.upload_url"}), None, "refused \\(HTTP 400\\)"),
+        ((403, {"code": "unauthenticated:bad-credentials", "error": "The OAuth2 access token could not be validated."}), None, "rejected the credential \\(grok-login\\) with HTTP 403"),
+        ((200, {"request_id": "r"}), [(200, {"status": "failed", "error": "nsfw"})], "status='failed'"),
+        ((200, {"request_id": "r"}), [(200, {"status": "expired"})], "status='expired'"),
+        ((200, {"request_id": "r"}), [(500, {"raw": "boom"})], "HTTP 500"),
+        ((200, {"request_id": "r"}), [(200, {"status": "done", "video": {}})], "reported no video url"),
+    ],
+)
+def test_api_failures_are_named_and_write_nothing(tmp_path: Path, post, polls, expected) -> None:
+    api = _FakeApi(post=post, polls=polls)
+    request = _request(tmp_path)
+    with pytest.raises(SystemExit, match=expected):
+        video.generate_video(request, credential=video.Credential("t", video.AUTH_SOURCE_GROK_LOGIN), call=api.call, download=api.download, sleep=lambda s: None)
+    assert not request.out.exists()
+    assert not list(tmp_path.glob("*.part"))
+
+
+def test_bad_credential_prescribes_refresh_for_login_and_check_for_key(tmp_path: Path) -> None:
+    api = _FakeApi(post=(403, {"error": "bad"}))
+    with pytest.raises(SystemExit, match=video.GROK_REFRESH_COMMAND.split()[0]):
+        video.generate_video(_request(tmp_path), credential=video.Credential("t", video.AUTH_SOURCE_GROK_LOGIN), call=api.call, download=api.download, sleep=lambda s: None)
+    with pytest.raises(SystemExit, match="check the XAI_API_KEY value"):
+        video.generate_video(_request(tmp_path), credential=video.Credential("t", video.AUTH_SOURCE_API_KEY), call=api.call, download=api.download, sleep=lambda s: None)
+
+
+def test_poll_timeout_fails_loud(tmp_path: Path, monkeypatch) -> None:
+    api = _FakeApi(polls=[(200, {"status": "pending"})])
+    clock = {"t": 0.0}
+    monkeypatch.setattr(video.time, "monotonic", lambda: clock["t"])
+
+    def sleep(seconds: float) -> None:
+        clock["t"] += seconds
+
+    request = _request(tmp_path)
+    with pytest.raises(SystemExit, match="poll timeout"):
+        video.generate_video(request, credential=video.Credential("t", "XAI_API_KEY"), call=api.call, download=api.download, sleep=sleep, poll_timeout=10)
+    assert not request.out.exists()
+
+
+def test_non_mp4_download_is_refused(tmp_path: Path) -> None:
+    api = _FakeApi()
+    api.payload = b"<html>not a video</html>"
+    request = _request(tmp_path)
+    with pytest.raises(SystemExit, match="not an mp4"):
+        video.generate_video(request, credential=video.Credential("t", "XAI_API_KEY"), call=api.call, download=api.download, sleep=lambda s: None)
+    assert not request.out.exists()
+
+
+@pytest.mark.parametrize(
+    ("overrides", "expected"),
+    [
+        ({"duration": 0}, "--duration must be 1..15"),
+        ({"duration": 16}, "--duration must be 1..15"),
+        ({"resolution": "4k"}, "--resolution must be one of"),
+        ({"aspect_ratio": "21:9"}, "--aspect-ratio must be one of"),
+        ({"prompt": "   "}, "empty prompt"),
+    ],
+)
+def test_request_validation_runs_before_any_call(tmp_path: Path, overrides, expected) -> None:
+    api = _FakeApi()
+    with pytest.raises(SystemExit, match=expected):
+        video.generate_video(_request(tmp_path, **overrides), credential=video.Credential("t", "XAI_API_KEY"), call=api.call, download=api.download)
+    assert api.calls == []
+
+
+def test_missing_still_fails_before_any_call(tmp_path: Path) -> None:
+    api = _FakeApi()
+    with pytest.raises(SystemExit, match="still image not found"):
+        video.generate_video(video.VideoRequest(image=tmp_path / "nope.png", prompt="p", out=tmp_path / "o.mp4"), credential=video.Credential("t", "XAI_API_KEY"), call=api.call, download=api.download)
+    assert api.calls == []
+
+
+# --- CLI ---------------------------------------------------------------------
+
+
+def test_cli_run_writes_report_and_defaults(tmp_path: Path, monkeypatch) -> None:
+    api = _FakeApi()
+    monkeypatch.setattr(video, "resolve_credential", lambda **_: video.Credential("t", video.AUTH_SOURCE_API_KEY))
+    monkeypatch.setattr(video, "http_json", api.call)
+    monkeypatch.setattr(video, "http_download", api.download)
+    monkeypatch.setattr(video.time, "sleep", lambda s: None)
+    out = tmp_path / "clip.mp4"
+    report = tmp_path / "report.json"
+
+    rc = video.run(image=_still(tmp_path), prompt="sway", prompt_file=None, out=out, duration=6, resolution="720p", aspect_ratio=None, model=video.DEFAULT_MODEL, generate_audio=None, report=report)
+
+    assert rc == 0
+    assert out.read_bytes() == MP4
+    payload = json.loads(report.read_text(encoding="utf-8"))
+    assert payload["auth_source"] == "XAI_API_KEY" and payload["out"] == str(out.resolve())
+
+
+def test_cli_parser_shape() -> None:
+    parser = video._build_parser()
+    args = parser.parse_args(["--image", "a.png", "--prompt", "p", "--out", "o.mp4"])
+    assert args.duration == 6 and args.resolution == "720p" and args.aspect_ratio is None and args.generate_audio is None
+    assert parser.parse_args(["--image", "a.png", "--out", "o.mp4", "--no-audio"]).generate_audio is False
+    assert parser.parse_args(["--image", "a.png", "--out", "o.mp4", "--audio"]).generate_audio is True
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--image", "a.png", "--out", "o.mp4", "--resolution", "4k"])
+
+
+def test_unified_cli_exposes_video() -> None:
+    from sprite_gen import cli
+
+    assert "video" in cli.COMMANDS
+    parser = cli._build_parser()
+    args = parser.parse_args(["video", "--image", "a.png", "--prompt", "p", "--out", "o.mp4"])
+    assert args.command == "video"

--- a/tests/packaging/test_package_surface.py
+++ b/tests/packaging/test_package_surface.py
@@ -37,6 +37,7 @@ PACKAGE_RUN_MODULES = [
     "serve_curation",
     "slice_sheet",
     "unpack_atlas",
+    "video",
 ]
 
 CLI_HELPERS = [


### PR DESCRIPTION
## Summary

`sprite-gen video --image still.png --prompt "..." --out clip.mp4` animates one still through Grok Imagine (`POST /v1/videos/generations`) into a verified mp4, using the user's **own** credential. Nothing is shipped with the repo.

- Credential order is fixed and reported (`auth_source`): `XAI_API_KEY` when set, otherwise the `grok` CLI login file (`~/.grok/auth.json`, `GROK_HOME` honoured). A set-but-empty key, a missing credential, or a login file with several accounts each fail by name with the setup path spelled out.
- The grok login token expires (about six hours). The run reads `expires_at` before uploading and stops with the exact refresh command instead of rewriting the CLI's file.
- Request validation (duration 1..15, 480p/720p/1080p, seven aspect ratios, prompt, still) runs before any network call. Refused requests, `failed`/`expired` generations, non-2xx polls, the poll timeout, and a non-mp4 download each fail loudly and write nothing; the mp4 is `ftyp`-verified and moved into place atomically.
- Tokens and download URLs never reach stdout or the report (only the download host).
- New `scripts/generate_sprite_video.py` wrapper, `docs/video.md` (setup, why the direct API call and not Grok Build's `image_to_video` tool on ZDR teams, quotas), README section, SKILL.md entries. Version 1.60.0 -> 1.61.0, CHANGELOG `v1.61.0 - Image to Video`.

## Verification

- `tests/gen/test_video.py`: 25 cases with a scripted fake API (no network). `tests/gen` + `tests/packaging`: 393 passed; full `pytest -q` green.
- Real E2E with the grok login: fox still -> 6 s 720p clip, 1,372,881 bytes, h264 928x976 24 fps 145 frames, `auth_source: grok-login`, 9 polls, 39 s.

https://claude.ai/code/session_01UD5XPWHHy5tMJ4DKMaX9iv
