### PR TITLE
video-loop: --body-height is a target, so a short state scales up too

### DIFF
--- a/sprite_gen/video/loop.py
+++ b/sprite_gen/video/loop.py
@@ -274,9 +274,14 @@ def build_strip(frames: list[Image.Image], *, max_cells: int = STRIP_MAX_CELLS, 
     floor = max(b[3] for b in boxes)
     grounded = [b[3] - b[1] for b in boxes if b[3] >= floor - 4] or [b[3] - b[1] for b in boxes]
     body_src = max(grounded)
-    scale = min(1.0, max_height / (bottom - top))
-    if body_height is not None:
-        scale = min(scale, body_height / body_src)  # match the standing height; max_height stays an upper bound
+    # max_height is a ceiling on the CELL; an explicit body_height is a target for the BODY.
+    # Without one, nothing is ever scaled up. With one, a state whose source body is SHORTER
+    # than the request has to grow — clamping to 1.0 first made the option a downward clamp
+    # only, so "the same value across states gives the same character size" was false for
+    # exactly the states that needed it: a 200 px source and a 400 px source both asked for
+    # 300 came out 200 and 300 (measured 2026-09-10). The cap still wins over the target.
+    fit = max_height / (bottom - top)
+    scale = min(1.0, fit) if body_height is None else min(fit, body_height / body_src)
     w = round((right - left) * scale)
     h = round((bottom - top) * scale)
     cap = max(1, min(max_cells, max_width // max(1, w)))
@@ -515,7 +520,7 @@ def add_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--cycle", choices=CYCLE_MODES, default="auto", help="auto: periodic first, one-shot failover for action states (recorded in the report); periodic / one-shot force one detector; fixed cuts exactly --start/--length (no detection, reported as kind=fixed)")
     parser.add_argument("--start", type=int, help="fixed cut: first keyed frame of the cycle (with --cycle fixed)")
     parser.add_argument("--length", type=int, help="fixed cut: cycle length in frames (with --cycle fixed)")
-    parser.add_argument("--strip-height", type=int, default=STRIP_MAX_HEIGHT, help=f"cell/strip/GIF height cap in px (default {STRIP_MAX_HEIGHT}); the cycle is scaled down to fit, never up")
+    parser.add_argument("--strip-height", type=int, default=STRIP_MAX_HEIGHT, help=f"cell/strip/GIF height cap in px (default {STRIP_MAX_HEIGHT}); the cycle is scaled down to fit, and never up unless --body-height asks for it")
     parser.add_argument("--body-height", type=int, help="scale so the STANDING height (tallest floor-contact frame) is this many px — the same value across states gives the same character size; --strip-height stays the cap")
     parser.add_argument("--name", default="loop", help="basename for strip/gif/webp outputs")
     parser.add_argument("--report", type=Path)

--- a/tests/video/test_video_pipeline.py
+++ b/tests/video/test_video_pipeline.py
@@ -362,6 +362,35 @@ def test_body_h_is_the_standing_height_not_the_cycle_median() -> None:
     assert meta3["h"] <= 40, "--strip-height stays the cap"
 
 
+def test_body_height_is_a_target_across_states_not_a_downward_clamp() -> None:
+    """`--body-height` exists so the same number across states gives one character size.
+    That only holds if a state whose source body is SHORTER than the request scales UP:
+    a 40 px walk and an 80 px jump both asked for 60 must both come out 60. Clamping the
+    scale to 1.0 first left the short one at 40 and the tall one at 60 — two sizes from
+    the one option meant to produce one."""
+    def body(height: int) -> Image.Image:
+        im = Image.new("RGBA", (80, 120), (0, 0, 0, 0))
+        for y in range(120 - height, 120):        # standing on the floor
+            for x in range(30, 50):
+                im.putpixel((x, y), (200, 60, 60, 255))
+        return im
+
+    short = [body(40) for _ in range(4)]
+    tall = [body(80) for _ in range(4)]
+    _, short_meta = loop_mod.build_strip(short, cycle_seconds=4 / 24, body_height=60)
+    _, tall_meta = loop_mod.build_strip(tall, cycle_seconds=4 / 24, body_height=60)
+    assert short_meta["body_h"] == tall_meta["body_h"] == 60
+
+    # No body_height still never scales up: that is what --strip-height is for.
+    _, plain = loop_mod.build_strip(short, cycle_seconds=4 / 24)
+    assert plain["body_h"] == 40
+
+    # The cell cap still beats the target, and the miss stays visible in the meta.
+    _, capped = loop_mod.build_strip(short, cycle_seconds=4 / 24, body_height=60, max_height=40)
+    assert capped["h"] <= 40
+    assert capped["body_height_target"] == 60 and capped["body_h"] < 60
+
+
 def test_drop_specks_erases_detached_slivers_only() -> None:
     im = Image.new("RGBA", (40, 40), (0, 0, 0, 0))
     for y in range(5, 35):


### PR DESCRIPTION
`--body-height N` is documented as the way to get one character size across states — `docs/video-pipeline.md` says "so every state comes out at the same character size", and the CLI help says "the same value across states gives the same character size". `build_strip` does not deliver that, because the scale is clamped to 1.0 before the body target is applied:

```python
scale = min(1.0, max_height / (bottom - top))
if body_height is not None:
    scale = min(scale, body_height / body_src)
```

Both `min`s only ever reduce, so the option can shrink a state but never grow one. Measured against v2.0.3 with two synthetic cycles standing on the floor, both asked for `--body-height 300`:

```
source body 200  ->  achieved body 200
source body 400  ->  achieved body 300
```

Two sizes out of the one option meant to produce one. It happens to work whenever every state's source body already exceeds the request, which is why the regenerated heroes look right — the paladin states are all taller than the target.

The change applies the cell cap and the body target as two separate bounds. With no `body_height` nothing is scaled up, which is what `--strip-height` is for. With one, the target may take the scale above 1.0, and the cap still wins over the target, so `--strip-height` remains what its help says it is. `Image.LANCZOS` is already the resampler, so the upscale path needs nothing new.

`test_body_h_is_the_standing_height_not_the_cycle_median` asked for 30 px from a 60 px source, so the whole upscale direction was untested. The new test drives a 40 px and an 80 px cycle through the same `--body-height 60` and asserts both come out 60, plus that the no-target path still never scales up and that the cap still beats the target with the miss visible in `body_h` against `body_height_target`.

Full suite 1068 passed, 6 skipped. Without the fix the new test fails on `assert 40 == 60`; the two existing `body_h` assertions are unchanged and still pass.

I also softened one clause in the `--strip-height` help, which said "never up" — that is still true unless `--body-height` asks for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
