### PR TITLE
docs: clarify body-height upscaling and credit PR 28

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -37,4 +37,8 @@ The following external contributors have work that is incorporated into, or mate
 
 - [PR #16](https://github.com/aldegad/sprite-gen/pull/16): added support for Codex `image_gen.generation` Extension result records while preserving the existing inline PNG verification path.
 
+## [@Chang-Jin-Lee](https://github.com/Chang-Jin-Lee)
+
+- [PR #28](https://github.com/aldegad/sprite-gen/pull/28): made explicit character-height targets scale smaller video sprites up while preserving the cell-height cap.
+
 Thank you for testing the project in real environments, documenting failures clearly, and contributing fixes or experiments that inform `sprite-gen`.

--- a/docs/video-pipeline.md
+++ b/docs/video-pipeline.md
@@ -131,8 +131,8 @@ Outputs:
   (default 24 fps = the source rate, so every cycle frame is kept; floor 4, never more than
   the cycle holds). A fixed 12 made a 2.5 s jump hold each frame 210 ms while a 1.1 s walk
   held 90 ms, and even an even 12 fps read sluggish on a jump (2026-09-09). `--n-out` and
-  `--gif-fps` still override; `--strip-height` caps the cell/strip/GIF height (scaled down,
-  never up) when the output has a target size such as a README hero.
+  `--gif-fps` still override; `--strip-height` caps the cell/strip/GIF height. Scaling up
+  requires an explicit `--body-height` target and still respects that cap.
 - `<name>.webp` — same frames, lossless, `img2webp -exact` (Pillow's animated WebP writer
   does not pass `exact` and rewrites RGB under transparent pixels).
 


### PR DESCRIPTION
The video-loop documentation still said output never scales up after PR #28 made explicit body-height targets support upscaling. Clarify that the cell-height cap remains in effect and credit Chang-Jin-Lee for the fix.

Validation: the integrated code and documentation passed all 1,108 tests locally. This commit changes documentation only; its final tree matches the tested tree.
