### PR TITLE
Add agy provider (Antigravity CLI, subscription-backed chroma gen)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -66,7 +66,7 @@ Pass choices already stated in the request. The guide checks access, combines ex
 | GPT image sprites | `prepare`, `gen-set --provider codex`, `extract`, compose and QA | [atlas-workflow](docs/atlas-workflow.md) |
 | Standalone video / animate a still | `video` | [video](docs/video.md) |
 | Grok video sprites | `video-set` | [video-pipeline](docs/video-pipeline.md) |
-| Ordinary image or edit | `gen --provider codex` or `gen --provider grok` | [gen](docs/gen.md) |
+| Ordinary image or edit | `gen --provider codex`, `--provider grok`, or `--provider agy` (optional, only if the Antigravity CLI is installed) | [gen](docs/gen.md) |
 | Base and direction anchors | `anchor` | [directional-anchor-workflow](docs/directional-anchor-workflow.md) |
 | Curation view or existing image candidates | `curation`, `unpack-atlas --pngs-dir` | [curation](docs/curation.md) |
 | Uniform background removal or imported sheets | `cutout`, `slice-sheet` | [sheet-slicing](docs/sheet-slicing.md) |

--- a/docs/gen.md
+++ b/docs/gen.md
@@ -8,12 +8,16 @@ disk, with an optional transparent output whose strategy is decided per provider
 (native alpha or deterministic chroma keying). The general `image-gen` skill is a
 thin shuttle over this command.
 
-Providers (Gemini/OpenRouter/fal/BytePlus are intentionally **not** included):
+Providers — every one is a **subscription/OAuth-backed surface the user already pays
+for**, never a metered image API we hold a key to (the Gemini/OpenRouter/fal/BytePlus
+APIs are intentionally **not** included; `agy` reaches Google's models through the
+user's own Antigravity CLI sign-in, which is the same category as codex, not an API):
 
 | Provider | Backend | Auth | Output truth | Transparency strategy |
 |---|---|---|---|---|
 | `codex` | codex `image_gen` | ChatGPT OAuth | inline base64 in the session rollout jsonl, decoded deterministically | **`native`** — image_gen returns a real alpha channel when asked (measured, then published) |
 | `grok` | direct Imagine `/images/generations` or `/images/edits` | Grok login or `XAI_API_KEY` | inline bytes decoded and re-encoded as a verified PNG | `chroma` — Imagine returns JPEG only; generate on a key and matte it out |
+| `agy` | Antigravity CLI (`agy -p … --output-format json`) | Google AI Pro subscription (signed in inside the CLI; no API key) | a file the agent writes at the absolute path we name, decoded and verified — the reported path is parsed but never trusted | `chroma` — the model returns an opaque raster; the adapter has it paint a flat key backdrop and sprite-gen mattes it out |
 
 The strategy is declared **once**, on the adapter (`Provider.transparency`), and is
 the only place that says what a backend can do. See
@@ -24,7 +28,7 @@ the only place that says what a backend can do. See
 `--provider` is **optional**. When omitted, the backend is resolved by a fixed
 precedence (maintainer 확정 2026-07-17):
 
-1. **`SPRITE_GEN_DEFAULT_PROVIDER`** env var (`codex` or `grok`) — the user override.
+1. **`SPRITE_GEN_DEFAULT_PROVIDER`** env var (`codex`, `grok` or `agy`) — the user override.
    An unknown value fails loud.
 2. **`codex`** — the hard default (GPT `image_gen`).
 
@@ -33,7 +37,11 @@ or `codex login status` reports not-logged-in), the resolution **falls back to
 `grok` — observably, never silently**: a stderr notice is printed and the report
 JSON records `provider_fallback` (`from`/`to`/`reason`/`default_source`). The
 grok default (`SPRITE_GEN_DEFAULT_PROVIDER=grok`) has no reverse fallback — a down
-grok fails loud at generation time.
+grok fails loud at generation time. **`agy` sits outside the failover in both
+directions**: it is selectable explicitly or as `SPRITE_GEN_DEFAULT_PROVIDER`, but it
+is never chosen *for* the user, because a 60–130 s agent turn is not a drop-in
+substitute for a stalled default; an `agy` default that is down likewise fails loud at
+generation time.
 
 An **explicit `--provider`** is always honored verbatim — it is never overridden by
 the availability fallback. An explicitly named provider that is down fails loud
@@ -80,7 +88,7 @@ API contracts: [image generation](https://docs.x.ai/developers/model-capabilitie
 
 ```bash
 sprite-gen gen \
-  [--provider codex|grok] # optional; default = SPRITE_GEN_DEFAULT_PROVIDER env → codex (observable grok fallback if codex is down)
+  [--provider codex|grok|agy] # optional; default = SPRITE_GEN_DEFAULT_PROVIDER env → codex (observable grok fallback if codex is down)
   --prompt "…"            # or --prompt-file PROMPT.txt
   --out DEST.png \
   [--ref REF.png ...]     # repeatable; Grok accepts up to five references
@@ -101,7 +109,7 @@ Backward-compatible wrapper: `$SPRITE_GEN_ROOT/.venv/bin/python $SPRITE_GEN_ROOT
   report is published** (No Silent Fallback).
 - The pre-process raw is preserved next to the destination as `<out>.raw.png` for audit.
 - `--report` writes a `sprite-gen-image-report` JSON: provider, prompt, out/raw paths,
-  `raw_bytes`, `elapsed_seconds`, `session_id` (codex), an `alpha` block
+  `raw_bytes`, `elapsed_seconds`, `session_id` (codex's rollout session, agy's conversation id), an `alpha` block
   (`strategy` + the measured stats), the `chroma` stats when chroma keying ran, and the
   provider-resolution fields (`provider_resolved_from`, and `provider_fallback` when a
   codex→grok default fallback occurred).
@@ -114,7 +122,7 @@ strategy it can execute, and `--alpha-mode auto` (the default) follows it:
 | Strategy | Who | What happens | Refused when |
 |---|---|---|---|
 | `native` | `codex` (**first choice**, 2026-09-08) | The transport prompt asks image_gen for a genuinely transparent background (the bundled `imagegen` skill honours "transparent background" and keeps the generated alpha; codex reports `transparentBackground: true` on the completed item). The decoded PNG's alpha is **measured**: no alpha band or `alpha_zero_pct: 0.0` refuses to publish, RGB under alpha 0 is scrubbed, partial alpha (1–254) is left as produced and reported as `partial_alpha_pct`. | The model drew a checkerboard / flat background (RGB image) — nothing can recover alpha from that, so the run fails instead of silently keying. |
-| `chroma` | `grok` (only option), `codex` with `--alpha-mode chroma` | Generate on a `#FF00FF` (or `#00FF00`) background — pick the key by subject colour (magenta subjects → green key) — and matte it out through the frame extractor's canonical YCbCr matte (`remove_chroma_background_ycbcr`), which keys from the background chroma it detects on the borders (`detect_background_key_ycc`) rather than from the pure key alone — the RGB matte behind `cutout`/`extract`/`slice-sheet` does the same since 2026-09-11 (`detect_background_key_rgb`), so every chroma path tolerates the slightly-off green/magenta generators actually paint. Gradients and texture within that chroma family are supported. | `alpha_zero_pct: 0.0` after keying, or stale RGB under alpha 0. |
+| `chroma` | `grok` and `agy` (only option for both), `codex` with `--alpha-mode chroma` | Generate on a `#FF00FF` (or `#00FF00`) background — pick the key by subject colour (magenta subjects → green key) — and matte it out through the frame extractor's canonical YCbCr matte (`remove_chroma_background_ycbcr`), which keys from the background chroma it detects on the borders (`detect_background_key_ycc`) rather than from the pure key alone — the RGB matte behind `cutout`/`extract`/`slice-sheet` does the same since 2026-09-11 (`detect_background_key_rgb`), so every chroma path tolerates the slightly-off green/magenta generators actually paint. Gradients and texture within that chroma family are supported. | `alpha_zero_pct: 0.0` after keying, or stale RGB under alpha 0. |
 
 - **`auto` steps down to `chroma` when `--ref` is attached**, even on codex. Measured
   2026-09-08 (plan `sprite-gen/parts-rig`): codex `image_gen` with reference images
@@ -130,6 +138,10 @@ strategy it can execute, and `--alpha-mode auto` (the default) follows it:
 - `--alpha-mode native` on a `chroma`-only provider **fails loud before any model
   call** — a strategy the backend cannot execute is not a fallback candidate, and
   native → chroma never happens silently either (the prompt shapes are different).
+- Why agy is chroma-only: its image model returns an opaque raster and the CLI exposes
+  no transparency parameter. Alpha from the agent's own segmentation was measured
+  working on 2026-09-12 and **rejected on purpose** — see [agy](#agy-antigravity-cli).
+  `--alpha-mode native` on agy fails before any model call.
 - Why grok is chroma-only: Grok Imagine Image 2.0 returns `image/jpeg` from both the
   `/v1/images/*` API and the CLI `image_gen`/`image_edit` tools, and the official
   docs expose no background parameter — its "background removal" is a consumer-app
@@ -171,6 +183,112 @@ change it; and no `config.toml` feature toggle grants it. The remedy is to point
 exactly that, rather than falling back on its own.
 - **grok** — uses the [direct API contract](#direct-grok-calls-and-authentication) above.
 
+### agy (Antigravity CLI)
+
+`sprite-gen gen --provider agy` spawns one non-interactive turn:
+`agy --output-format json --add-dir <out dir> [--add-dir <ref dir> …] [--model ID] -p "<prompt>"`.
+
+- **Auth** — a Google AI Pro subscription signed in inside the CLI. There is no API
+  key and no env var; sprite-gen never sees a credential. Antigravity exposes **no
+  offline login-status subcommand**, so `sprite-gen workflow` reports agy's login as
+  *unknown* (CLI present on PATH) and asks the user to confirm the account rather than
+  asserting it — it will not spend a quota round trip to find out.
+- **One-time local setup** — set `Tool Permission` to `always-proceed` (run `agy`, then
+  `/config`). The adapter deliberately does **not** pass
+  `--dangerously-skip-permissions`: silently disabling an operator's approval gate is
+  not an adapter's decision. A machine that skipped this setup stalls on the approval
+  prompt and is killed by the timeout below, whose message says exactly that.
+- **Output truth** — the prompt names `request.raw`'s absolute path as the one file to
+  write, and that directory is in the workspace via `--add-dir`. The destination is
+  **unlinked before the spawn**, so its existence afterwards proves *this* run wrote it
+  (a reused `--workdir` cannot hand back a stale image). The paths the agent claims in
+  its prose `response` are parsed too — markdown `[name](file:///…)` links,
+  `**File:**`/`**Folder:**` detail pairs, and bare absolute paths — and published as
+  `extra.reported_paths`; they are used as the *recovery* route when the named
+  destination was not written (recorded as `extra.recovered_from`, never silent).
+  Either way `verify_png` decodes the bytes before success is claimed.
+- **References** — agy's print mode has no image-input flag (`-i` is
+  `--prompt-interactive`, not an image). References ride the workspace instead: each
+  ref's directory is passed with `--add-dir` and the absolute paths are named in the
+  prompt. Verified 2026-09-12 — the agent opened a PNG from an added directory and
+  described its contents correctly, so this is real vision input.
+- **Transparency is chroma, and that is a deliberate reversal** — agy's model returns an
+  **opaque** raster, so alpha has to come from somewhere. The first cut of this adapter
+  asked for "a transparent background" and the agent answered by installing and running
+  `rembg` on its own initiative. It produced real alpha — and was replaced anyway,
+  because "the agent decides how to matte" is a different program on every run (a
+  different tool, different parameters, a silently skipped step, or ~1 GB of U²-Net
+  weights downloaded mid-generation). The adapter now has it paint a flat key backdrop
+  and `chroma.key_transparent` — the same tested YCbCr matte behind
+  `extract`/`cutout`/`slice-sheet`/grok — makes the alpha. One extraction path, in code
+  we own. On transparency agy is therefore in grok's category (a backend that cannot
+  return alpha) even though its auth model is codex's: backend capability picks the
+  strategy, the auth model does not.
+- **The adapter states the key; grok's does not** — grok is a bare API that paints
+  exactly the background the caller's prompt describes, so its adapter stays out of it
+  and the sprite-row prompts carry the key. An agent left unbriefed picks its own
+  background and, measured, mattes it out unasked. So `agy_provider` injects a background
+  block — with the reason stated, because an agent that understands why the flat colour
+  is wanted is much less likely to "improve" on it. The block has **two independent
+  pieces, and they apply at different times**:
+  - *Never matte it yourself* (`do not remove the background, do not run rembg or any
+    background-removal / segmentation / matting / cutout tool, do not output an alpha
+    channel, do not draw a checkerboard`) goes in on **every agy run, keyed or not**.
+    That is an invariant of the adapter, not a property of one code path. It matters
+    most where `--transparent` is never passed: `gen-set`, `reroll` and `interpolate`
+    generate rows whose prompts already carry the run's key and let `extract` matte
+    later, so an agy row that helpfully segmented itself would reach
+    `remove_chroma_background_ycbcr` with no chroma left to key.
+  - *Paint this exact key* (`a completely flat, solid, uniform #FF00FF` or `#00FF00`
+    backdrop) is added **only when the key is known**, from `GenRequest.chroma_key` —
+    which the orchestrator sets to the very key it is about to matte out, so the painted
+    background and the matte can never disagree. On the pipeline paths the key is *not*
+    known here (`prepare.py` picks it per run, auto magenta/green from the base image,
+    and writes it into each row prompt itself, while `gen`'s own `--chroma-key` is just
+    its `magenta` default). Naming a guessed colour there could contradict a green run,
+    so the adapter names none and the caller's prompt stays the single source of the
+    backdrop.
+- **Latency** — ~54 s wall / ~48 s of agy turn (2026-09-12 실측, magenta key). The
+  earlier agent-mattes-itself design measured ~64 s warm and ~130 s on its first run
+  (the one-time rembg download); removing the ML step removed that variance along with
+  ~10 s. agy is still by far the slowest of the three providers — a full agent turn per
+  image — so pick it for its account/quota, not for throughput.
+- **Timeout** — agy gets its own bound, `AGY_GEN_TIMEOUT_SECONDS` (default 420 s,
+  override with `SPRITE_GEN_AGY_TIMEOUT_SECONDS`) instead of the shared 180 s
+  `GEN_TIMEOUT_SECONDS`. 180 s leaves almost no headroom over the ~130 s cold path, and
+  agy has its own `--print-timeout` (default 5m0s) for the background tools it spawns —
+  our kill has to sit *above* that, or we shoot the child while it is still inside its
+  own bounded wait and lose the structured JSON error it was about to print.
+- **Report fields** — `session_id` carries agy's `conversation_id` (same role as codex's
+  rollout session id), and `extra` carries `transport: "agy-cli"`, `conversation_id`,
+  `num_turns`, `usage`, `agy_duration_seconds` (agy's own clock, next to sprite-gen's
+  measured `elapsed_seconds`), `reported_paths`, `recovered_from`,
+  `chroma_key_requested` and `refs`. The matte's own stats land in the standard `chroma`
+  block (`key`, `keyed_pixels`, `fringe_pixels`, `alpha_zero_pct`), exactly as for grok.
+- **Security note — the background rule is a soft, unenforced control.** Worth being
+  blunt about, because the rest of this section reads like a guarantee and it is not
+  one. The anti-self-matting instruction is *prose in a prompt*. Nothing sandboxes or
+  rate-limits what the agy agent does with its shell access — `--add-dir` points it at a
+  workspace, it does not fence it in, and the `always-proceed` tool permission the setup
+  step asks for is precisely what lets it install and run whatever it decides it needs.
+  This agent has already installed and run a Python package unprompted; that is the
+  measured behaviour the design exists to stop, not a hypothetical. Assume the
+  instruction can be ignored on any given run.
+  What is actually enforced, without the agent's cooperation: the destination is
+  unlinked before the spawn (only a file from *this* run can be published); recovery
+  paths parsed out of the response are fully resolved — defeating `..` traversal and
+  symlinks — and **refused unless they land inside the output directory or the working
+  directory**, with reference images never eligible as output; and `verify_png` decodes
+  the bytes before success is claimed. A disobeyed prompt therefore surfaces as a loud
+  failure (`key_transparent` finds no chroma to key, or recovery refuses every
+  candidate) rather than a silently wrong sprite.
+  Residual risk, stated rather than solved: a cooperating-but-wrong agent that writes a
+  valid PNG of the wrong subject to the right path is indistinguishable from a correct
+  run at this layer. Curation and QA downstream are where that is caught.
+- **Not in `SKILL.md`'s `required_bins`** — that field means *always required*
+  (`codex`, `ffmpeg`, `img2webp`). Like grok, agy is an optional provider: it is needed
+  only when someone actually passes `--provider agy`.
+
 ## Sprite-row usage
 
 In the atlas pipeline (SKILL.md §2) the rows of a prepared run are generated by
@@ -201,6 +319,11 @@ On a 4-frame idle mushroom row, grok generated
 in ~18.4 s vs codex ~39.0 s (~2.1× faster). codex adhered better to negative constraints
 ("no grid lines"); grok added faint cell dividers. Pick per need: grok for speed, codex
 for tighter prompt adherence.
+
+`agy` is a different order of magnitude: ~54 s wall / ~48 s of agent turn (2026-09-12
+실측), because a whole agent turn — plan, generate, save — happens per image. It is the
+right pick when the Google AI Pro subscription is the quota you want to spend, not when
+throughput matters.
 
 ## Related
 

--- a/docs/gen.md
+++ b/docs/gen.md
@@ -265,6 +265,27 @@ exactly that, rather than falling back on its own.
   measured `elapsed_seconds`), `reported_paths`, `recovered_from`,
   `chroma_key_requested` and `refs`. The matte's own stats land in the standard `chroma`
   block (`key`, `keyed_pixels`, `fringe_pixels`, `alpha_zero_pct`), exactly as for grok.
+- **Not usable for multi-pose row generation — `gen-set` and `reroll` exclude it.**
+  Measured 2026-09-12 on a 4-pose walk-cycle prompt shaped like the ones `prepare.py`
+  writes (distinct gait poses, one identity, no grid or labels, flat chroma backdrop):
+  the turn **never finished**. It hit agy's own 5-minute `--print-timeout` still in
+  progress, burned **~240k tokens** (218k input via cache, 21k output, 9.8k thinking),
+  and returned `status: "SUCCESS"` with an **empty response and no file written
+  anywhere**. Single-subject prompts on the same machine finish in ~27-65 s.
+  The gap looks structural rather than one of degree: `codex image_gen` and grok
+  Imagine are single-shot image models doing one inference at exactly this
+  composition task, while agy is an agent that deliberates and iterates — the same
+  unpredictability class as the unasked-for `rembg` run below.
+  The adapter handled it correctly (no file → no recoverable candidate → loud
+  `SystemExit`, never a false success), so the exclusion is about not spending five
+  minutes and a quarter of a million tokens to reach a guaranteed failure, not about
+  safety. `agy` therefore stays fully available on **`gen`** (one image per call,
+  verified solid) and on **`interpolate`** (its prompt asks for "exactly ONE full-body
+  pose"), and is refused by **`gen-set`** and **`reroll`**, which regenerate a whole
+  row from one `prompts/<state>.txt`. The split lives in `sprite_gen.gen.ROW_PROVIDERS`.
+  **Not proven unfixable** — exactly one prompt shape was tried and no variations were
+  attempted. Widen it only on the strength of a run that actually produced a usable
+  row.
 - **Security note — the background rule is a soft, unenforced control.** Worth being
   blunt about, because the rest of this section reads like a guarantee and it is not
   one. The anti-self-matting instruction is *prose in a prompt*. Nothing sandboxes or

--- a/sprite_gen/effects/interpolate.py
+++ b/sprite_gen/effects/interpolate.py
@@ -12,16 +12,16 @@ AI 생성이다. 산출물은 최종 프레임이 아니라 **테이크 raw** (`
 (hero down_action 팔스윙: codex/grok/RIFE)에서 생성형이 중간 포즈를 깨끗한
 픽셀로 그려내 압승했다 — 근거 시트 `tween-3way-compare.png` (트레이 2026-07-17).
 
-인증 전제 (GUI 버튼 포함): 생성은 항상 **서버 머신의 provider CLI** (`codex`/`grok`)
+인증 전제 (GUI 버튼 포함): 생성은 항상 **서버 머신의 provider CLI** (`codex`/`grok`/`agy`)
 가 수행한다 — 브라우저·웹뷰에는 어떤 자격증명도 지나가지 않는다. 해당 CLI 가
-이 머신에 설치·로그인(ChatGPT OAuth / xAI OAuth)되어 있어야 하며, 미인증이면
+이 머신에 설치·로그인(ChatGPT OAuth / xAI OAuth / Google AI Pro)되어 있어야 하며, 미인증이면
 provider 가 요란하게 실패하고 그 메시지가 CLI/뷰 상태줄에 그대로 표면화된다.
 설정 절차는 [`docs/gen.md`](../docs/gen.md), 보간 관점 가이드는
 [`docs/frame-interpolation.md`](../docs/frame-interpolation.md).
 
 사용:
     python3 scripts/interpolate_frames.py --run-dir <run> --state down_idle \
-        --between 1 2 [--provider codex|grok] [--t 0.5] [--label blink_mid] [--extract]
+        --between 1 2 [--provider codex|grok|agy] [--t 0.5] [--label blink_mid] [--extract]
 
 - `--between A B`: 그 상태 primary 스트립의 프레임 인덱스 두 개 (추출된 컴포넌트 순서).
 - `--provider`: 생성 백엔드 (기본 codex — 3-way 비교 승자).
@@ -49,7 +49,10 @@ from sprite_gen.frames.extract import (extract_component_images, register_row_fr
 from sprite_gen.spec.layout import raw_rel, take_raw_rel
 from sprite_gen.spec.runio import load_request, write_request
 
-PROVIDERS = ("codex", "grok")
+# 보간은 두 프레임을 ref 로 물리므로 ref 를 받을 수 있는 provider 만 의미가 있는데,
+# codex(`-i`)/grok(images 배열)/agy(`--add-dir` + 프롬프트에 절대경로 명시, 2026-09-12 실측)
+# 모두 ref 를 받는다 — 즉 `sprite_gen.gen.PROVIDERS` 전부가 여기서도 유효하다.
+PROVIDERS = ("codex", "grok", "agy")
 
 # interpolator 시그니처: (img0 RGB, img1 RGB, t, prompt) -> mid RGB. 테스트는 스텁을 주입한다.
 Interpolator = Callable[[Image.Image, Image.Image, float, str], Image.Image]

--- a/sprite_gen/effects/reroll.py
+++ b/sprite_gen/effects/reroll.py
@@ -26,7 +26,7 @@ from typing import Any
 
 from sprite_gen.curate.anchor import identity_ref
 from sprite_gen.spec.runio import load_request, write_request
-from sprite_gen.gen import PROVIDERS, generate_image
+from sprite_gen.gen import ROW_PROVIDERS, generate_image
 from sprite_gen.spec.layout import guide_rel, prompt_rel, take_raw_rel
 
 
@@ -74,6 +74,18 @@ def reroll_state(run_dir: Path | str, state: str, provider: str = "codex",
     # 레거시 런에서 아래 `fit.pixel_unfake` 검사가 항상 False 가 되어, 언페이크가 켜진 런의
     # 리롤을 "켜져 있지 않다" 며 거부한다 (validator 검증 2026-07-26 R1 재현). 리롤은 뷰가 **별도
     # 서브프로세스**로 띄우므로 뷰 프로세스의 in-memory 이관도 여기로 넘어오지 않는다.
+    # 리롤은 `gen-set` 과 **같은 행 프롬프트**(`prompts/<state>.txt`) 로 다중 포즈 행 한 장을
+    # 통째로 다시 생성한다 — 프레임 한 장이 아니다. 따라서 행 생성이 불가능한 provider 는
+    # 여기서도 불가능하다 (agy: 4포즈 프롬프트가 자체 5분 타임아웃을 미완료로 넘기고 ~240k
+    # 토큰을 쓰고 파일을 하나도 남기지 않았다 — 2026-09-12 실측, 근거는 gen/__init__.py).
+    # argparse choices 밖에서도 막는 이유: 큐레이션 뷰(`serve_curation.run_reroll`)와 다른
+    # 파이썬 호출자는 CLI 를 거치지 않고 이 함수를 직접 부른다. 생성비를 쓰기 전에 막는다.
+    if provider not in ROW_PROVIDERS:
+        raise SystemExit(
+            f"reroll: provider {provider!r} cannot generate a multi-pose row "
+            f"(row-capable: {', '.join(ROW_PROVIDERS)}); reroll regenerates the whole "
+            "state row from its row prompt, not a single frame"
+        )
     request = load_request(run_dir)
     if state not in request.get("states", {}):
         raise SystemExit(f"unknown state: {state}")
@@ -107,8 +119,8 @@ def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument("--run-dir", required=True)
     parser.add_argument("--state", required=True)
-    parser.add_argument("--provider", choices=PROVIDERS, default="codex",
-                        help="생성 백엔드 (기본 codex)")
+    parser.add_argument("--provider", choices=ROW_PROVIDERS, default="codex",
+                        help="생성 백엔드 (기본 codex; 행 생성이라 agy 는 제외 — reroll_state 주석 참조)")
     parser.add_argument("--label", default=None, help="테이크 라벨 (기본 rerollN 자동 증가)")
     parser.add_argument("--extract", action="store_true",
                         help="기록 후 전체 배치 재추출까지 수행 (부분 추출은 팔레트 배치 결합 때문에 지원하지 않음)")

--- a/sprite_gen/gen/__init__.py
+++ b/sprite_gen/gen/__init__.py
@@ -52,6 +52,36 @@ from .codex_provider import CodexProvider
 from .grok_provider import GrokProvider
 
 PROVIDERS = ("codex", "grok", "agy")
+
+# Providers able to compose a MULTI-POSE ROW (several distinct gait poses, one
+# identity, no grid/labels) in a single call. `PROVIDERS` answers "can this backend
+# make an image"; this answers "can it make a sprite row", and those are not the same
+# question — so `gen` and `interpolate` (one figure per call) take the full list while
+# `gen-set` and `reroll` (a whole row per call, from the same `prompts/<state>.txt`)
+# take this one.
+#
+# agy is excluded, measured 2026-09-12 on a 4-pose walk-cycle prompt shaped like the
+# ones `prepare.py` writes: the turn **never finished**. It hit agy's own 5-minute
+# `--print-timeout` still in progress, burned ~240k tokens (218k input via cache, 21k
+# output, 9.8k thinking), and returned `status: "SUCCESS"` with an EMPTY response and
+# no file written anywhere. Single-subject prompts on the same machine complete in
+# ~27-65 s. The gap is structural rather than one of degree: codex `image_gen` and
+# grok Imagine are single-shot image models doing one inference, while agy is an agent
+# that deliberates and iterates on a hard compositional prompt — the same
+# unpredictability class as the unasked-for rembg run, and not something this adapter
+# can bound from the outside.
+#
+# `agy_provider` handled that run correctly (no file -> no recoverable candidate ->
+# loud SystemExit, never a false success), so this exclusion is not a safety patch. It
+# exists so nobody spends five minutes and a quarter of a million tokens reaching a
+# guaranteed failure.
+#
+# NOT PROVEN UNFIXABLE: exactly one prompt shape was tried, and no prompt variations
+# were attempted. Widen this only on the strength of a run that actually produced a
+# usable row, not on the assumption that a rewording would.
+ROW_INCAPABLE_PROVIDERS = ("agy",)
+ROW_PROVIDERS = tuple(name for name in PROVIDERS if name not in ROW_INCAPABLE_PROVIDERS)
+
 # `--alpha-mode`: `auto` reads the provider's declared strategy (the SSoT);
 # `native` / `chroma` force one. Forcing `native` on a chroma-only provider fails
 # loud — a strategy the backend cannot execute is not a fallback candidate.

--- a/sprite_gen/gen/__init__.py
+++ b/sprite_gen/gen/__init__.py
@@ -2,17 +2,20 @@
 """Unified image generation layer for sprite-gen.
 
 Single source of truth for provider-backed image generation: codex (`image_gen`,
-ChatGPT OAuth) and grok (Imagine, xAI OAuth). One call = prompt (+ optional refs)
--> one verified raw PNG, with an optional deterministic transparent chroma
-post-process. The general `image-gen` skill is a thin shuttle over `sprite-gen gen`.
+ChatGPT OAuth), grok (Imagine, xAI OAuth) and agy (Antigravity CLI, Google AI Pro
+subscription). One call = prompt (+ optional refs) -> one verified raw PNG, with an
+optional deterministic transparent chroma post-process. The general `image-gen`
+skill is a thin shuttle over `sprite-gen gen`.
 
 Transparency is a per-provider strategy (`Provider.transparency`, declared once
 in each adapter): codex `image_gen` returns a genuinely transparent PNG when asked
-(`native`), grok Imagine cannot and is keyed out of a chroma background (`chroma`).
+(`native`); grok Imagine and agy cannot, so both generate on a key background that
+sprite-gen mattes out itself (`chroma`) — agy's adapter states the key in its prompt
+because an agent, unlike a bare API, otherwise picks its own background.
 `--transparent` follows the provider's strategy unless `--alpha-mode` overrides it.
 
 CLI:
-    sprite-gen gen --provider codex|grok --prompt "..." --out DEST.png
+    sprite-gen gen --provider codex|grok|agy --prompt "..." --out DEST.png
         [--ref REF.png ...] [--transparent [--alpha-mode auto|native|chroma]
         [--chroma-key magenta|green]] [--white-check CHECK.png] [--model ID]
         [--aspect-ratio 1:1] [--report REPORT.json] [--keep-session]
@@ -44,10 +47,11 @@ from .base import (
     provider_subprocess_env,
     verify_png,
 )
+from .agy_provider import AgyProvider
 from .codex_provider import CodexProvider
 from .grok_provider import GrokProvider
 
-PROVIDERS = ("codex", "grok")
+PROVIDERS = ("codex", "grok", "agy")
 # `--alpha-mode`: `auto` reads the provider's declared strategy (the SSoT);
 # `native` / `chroma` force one. Forcing `native` on a chroma-only provider fails
 # loud — a strategy the backend cannot execute is not a fallback candidate.
@@ -71,6 +75,8 @@ def _make_provider(name: str, *, keep_session: bool):
         return CodexProvider(keep_session=keep_session)
     if name == "grok":
         return GrokProvider()
+    if name == "agy":
+        return AgyProvider()
     raise SystemExit(f"gen: unknown provider {name!r}; expected one of {', '.join(PROVIDERS)}")
 
 
@@ -163,7 +169,12 @@ def resolve_default_provider() -> tuple[str, dict[str, str] | None]:
 
     # The availability-driven fallback is codex -> grok only (the mandated default).
     # A grok default that is down fails loud at generation time rather than silently
-    # reverse-falling-back to codex.
+    # reverse-falling-back to codex. agy is deliberately outside this failover in
+    # either direction: it is selectable (explicitly, or as SPRITE_GEN_DEFAULT_PROVIDER)
+    # but never chosen FOR the user, because a ~63-130s agent turn is not a drop-in
+    # substitute for a stalled default (an agy turn is a whole agent run, ~63s 실측), and an
+    # agy default that is down likewise fails
+    # loud at generation time.
     if default == "codex":
         ok, reason = _codex_available()
         if not ok:
@@ -228,6 +239,10 @@ def generate_image(
             model=model,
             aspect_ratio=aspect_ratio,
             native_alpha=strategy == TRANSPARENCY_NATIVE,
+            # The same key `key_transparent` will matte out below, so a provider that
+            # has to state its background in a prompt states the right one, and the
+            # painted background can never disagree with the matte (see GenRequest).
+            chroma_key=chroma_key if strategy == TRANSPARENCY_CHROMA else None,
         )
         # 타임아웃 1회 관측 가능 재시도 — 산발 provider 스톨은 같은 호출 재시도로
         # 대부분 통과한다 (회귀 2026-07-19). 두 번째도 스톨이면 fail loud.
@@ -377,7 +392,8 @@ def add_arguments(parser: argparse.ArgumentParser) -> None:
         action="store_true",
         help=(
             "publish a transparent RGBA PNG using the provider's transparency strategy: "
-            "codex asks image_gen for real alpha (native), grok is keyed out of a chroma background"
+            "codex asks image_gen for real alpha (native); grok and agy are keyed out of a "
+            "chroma background (chroma)"
         ),
     )
     parser.add_argument(
@@ -386,7 +402,8 @@ def add_arguments(parser: argparse.ArgumentParser) -> None:
         default=ALPHA_MODE_AUTO,
         help=(
             "transparency strategy for --transparent: auto = the provider's declared strategy "
-            "(native on codex, but chroma whenever --ref is attached — native alpha with refs is unstable); "
+            "(native on codex, but chroma whenever --ref is attached — native alpha with refs is unstable; "
+            "chroma on grok/agy always); "
             "chroma forces chroma keying (e.g. a codex prompt that already carries a key background); "
             "native forces native alpha and is refused on a provider that cannot return alpha"
         ),

--- a/sprite_gen/gen/agy_provider.py
+++ b/sprite_gen/gen/agy_provider.py
@@ -67,6 +67,18 @@ Decisive flags (each read off `agy --help`, 2026-09-12):
   skipped that setup stalls on the approval prompt and is killed by the timeout
   below, whose message says so.
 
+Capability limit — one image per call, not a sprite row:
+- A single-subject prompt completes reliably in ~27-65 s. A MULTI-POSE ROW prompt (the
+  shape `prepare.py` writes for `gen-set`/`reroll`: several distinct gait poses, one
+  identity, no grid or labels) did not complete at all — 2026-09-12 실측: agy's own
+  5-minute `--print-timeout` expired with the turn still in progress, ~240k tokens
+  spent (218k input via cache, 21k output, 9.8k thinking), `status: "SUCCESS"` with an
+  empty response and no file anywhere. This adapter refused it correctly (no
+  recoverable candidate -> SystemExit), but the capability is simply not there.
+- `sprite_gen.gen.ROW_PROVIDERS` therefore excludes agy, and `gen-set`/`reroll` take
+  that list while `gen`/`interpolate` (one figure per call) take the full `PROVIDERS`.
+  Only one prompt shape was tried, so treat this as unproven rather than impossible.
+
 Security posture — read this before trusting the instructions above:
 - **The anti-self-matting rule is prose, and prose is not enforcement.** "Do NOT run
   rembg, any background-removal, segmentation, matting or cutout tool" is a request in

--- a/sprite_gen/gen/agy_provider.py
+++ b/sprite_gen/gen/agy_provider.py
@@ -1,0 +1,591 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Antigravity CLI (`agy`) provider — Google AI Pro subscription, no API key.
+
+Same category as `codex_provider`: a subscription-backed agent CLI, not a bare
+image API. `agy -p "<prompt>" --output-format json` runs one non-interactive
+turn; the agent picks the image model itself, writes the PNG to disk, and reports
+what it did in a free-text `response` field. There is no structured
+`output_path`, so the transport contract this adapter owns is:
+
+1. **We name the destination.** The prompt states `request.raw`'s absolute path as
+   the one file to write, and `--add-dir` puts that directory in the agent's
+   workspace so writing there needs no extra approval. Naming the exact path is
+   cleaner than parsing a relative path back out of prose, and it was verified to
+   work first try (2026-09-12 실측: `raw.png` landed byte-exact at the named path).
+2. **We still parse the response.** The reported path(s) are recorded in
+   `extra.reported_paths` and used as the resolution route whenever the named
+   destination was *not* written, so an agent that saved elsewhere is recovered
+   instead of silently failing. Reported, never trusted.
+3. **The bytes on disk decide.** `request.raw` is unlinked before the spawn, so
+   its existence afterwards proves *this* run wrote it (a reused `--workdir`
+   cannot hand us a stale image), and `verify_png` decodes it before we claim
+   success (No Silent Fallback, see `base.py`'s module docstring).
+
+Transparency — why `chroma` (a deliberate reversal, 2026-09-12):
+`Provider.transparency` selects which post-process `sprite_gen.gen.generate_image`
+runs: `native` -> `chroma.verify_native_alpha(raw, out)` (measure alpha the model
+already produced), `chroma` -> `chroma.key_transparent(raw, out)` (matte a
+`#FF00FF`/`#00FF00` background out with our own tested YCbCr keyer).
+
+agy's image model returns an **opaque** raster, so alpha can only come from a
+segmentation step. The first cut of this adapter let the agent supply that step: it
+was asked for "a transparent background", and it answered by installing and running
+`rembg` on its own initiative, which did produce real alpha (measured: corners
+alpha=0, subject alpha=255). That worked — and is exactly why it was replaced.
+**Transparency belongs to sprite-gen's pipeline, not to an agent's improvisation:**
+
+- *Determinism.* "The agent decides how to matte" is a different program on every
+  run. It can pick a different tool, change its parameters, silently skip the step,
+  or (as observed) spend most of a ~130 s first run downloading ~1 GB of U^2-Net
+  weights. `key_transparent` is code in this repo, with tests and a measured contract.
+- *One extraction path.* The chroma matte is the same `remove_chroma_background_ycbcr`
+  behind `extract` / `cutout` / `slice-sheet` / grok. Every additional way to obtain
+  alpha is another way for results to disagree.
+- *Category.* On transparency agy belongs with grok — a backend that cannot return
+  alpha, so we generate on a key and matte it out — even though its auth model (a
+  Google AI Pro subscription CLI) puts it with codex. Backend capability decides the
+  strategy; the auth model does not.
+
+The difference from grok is that grok is a bare API: it paints exactly the background
+the caller's prompt describes, so its adapter says nothing about the key and the
+sprite-row prompts carry it. An agent left unbriefed picks its own background and,
+measured, mattes it out unasked — so this adapter must both state the key and forbid
+the improvisation. It reads the key from `request.chroma_key`, which the orchestrator
+sets to the very key it will matte out, so the painted background and the matte can
+never disagree.
+
+Decisive flags (each read off `agy --help`, 2026-09-12):
+- `--output-format json`  one JSON object on stdout (`status`, `response`,
+  `duration_seconds`, `num_turns`, `usage`, `conversation_id`). Without it the
+  output is prose only and `status` is unavailable.
+- `--add-dir <dir>`  puts a directory in the agent's workspace. Used for the
+  destination directory and for each reference image's directory.
+- `--model <id>`  honours `request.model` when the caller pinned one.
+- NO `--dangerously-skip-permissions`  tool approval is a **one-time local setup**
+  (`agy` -> `/config` -> `Tool Permission` -> `always-proceed`), deliberately not
+  something a provider adapter turns on behind the operator's back. A machine that
+  skipped that setup stalls on the approval prompt and is killed by the timeout
+  below, whose message says so.
+
+Security posture — read this before trusting the instructions above:
+- **The anti-self-matting rule is prose, and prose is not enforcement.** "Do NOT run
+  rembg, any background-removal, segmentation, matting or cutout tool" is a request in
+  a prompt. Nothing sandboxes or rate-limits what the agy agent actually does with its
+  shell access, and this exact agent has already installed and run a Python package
+  unprompted (that is the measured behaviour this design exists to stop). Assume the
+  instruction can be ignored on any given run. What is real, and does not depend on the
+  agent cooperating, is the check afterwards: `key_transparent` fails loudly on an image
+  with no chroma left to key, so a disobeyed prompt surfaces as a failed run rather than
+  a silently wrong sprite.
+- **`--add-dir` is a workspace grant, not a jail.** It is what the agent is pointed at,
+  not a limit on what it can reach; the operator's `always-proceed` tool permission is
+  what actually lets it act. Everything this adapter does with agy's output therefore
+  treats it as untrusted: the destination is unlinked before the spawn so only a file
+  from THIS run can be published, recovery candidates parsed out of the response are
+  resolved (defeating `..` and symlinks) and refused unless they land inside
+  `write_roots`, reference images are never eligible as output, and `verify_png` decodes
+  the bytes before success is claimed.
+- **The residual risk is stated, not solved.** A cooperating-but-wrong agent that writes
+  a valid PNG of the wrong thing to the right path is indistinguishable from a correct
+  run at this layer. Curation/QA downstream is where that is caught.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import time
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+
+from .base import (
+    TRANSPARENCY_CHROMA,
+    GenRequest,
+    GenTimeoutError,
+    ProviderRun,
+    provider_binary,
+    provider_subprocess_env,
+    verify_png,
+)
+
+# agy gets its own hard timeout instead of base.GEN_TIMEOUT_SECONDS (180 s), for
+# two measured reasons:
+#   1. A full run is ~63 s (2026-09-12 실측: 62.96 s reported `duration_seconds`,
+#      single turn) and was ~130 s while the agent was still doing its own rembg
+#      segmentation. The chroma design removes the ML step, but an agent turn is
+#      still plan + generate + save, so 180 s leaves little headroom on a slow day.
+#   2. agy has its own `--print-timeout` (default 5m0s) for waiting on the
+#      background tools it spawns. Our kill must sit ABOVE that, otherwise we
+#      shoot the child while it is still inside its own bounded wait and lose the
+#      structured JSON error it was about to print. 420 s = agy's 300 s ceiling
+#      plus ~2 min of process startup/teardown slack.
+# The bound itself is not optional — an agent CLI that stalls with no output has
+# no remedy but a kill (same regression class as base.GEN_TIMEOUT_SECONDS).
+AGY_GEN_TIMEOUT_SECONDS = int(os.environ.get("SPRITE_GEN_AGY_TIMEOUT_SECONDS", "420"))
+
+# Hex for each `chroma.KEYS` name, stated in the prompt alongside the colour word.
+# A hex triplet is unambiguous where "magenta" is not (pink? purple? fuchsia?), and
+# `remove_chroma_background_ycbcr` keys from the background chroma it detects on the
+# borders rather than from the pure value, so a near-miss still mattes — but the
+# closer the generator paints, the cleaner the fringe.
+_KEY_HEX = {"magenta": "#FF00FF", "green": "#00FF00"}
+
+# The background instruction is TWO independent pieces, on purpose. They were one
+# block until a review caught the consequence (2026-09-12), and the split is the whole
+# fix — see `_build_prompt` for which piece applies when.
+#
+# 1. `_NO_SELF_MATTE_INSTRUCTION` — UNCONDITIONAL, every single agy run.
+#
+#    "sprite-gen owns transparency, agy never does" is an invariant of this adapter, not
+#    a property of one code path, so its instruction cannot be conditional either. That
+#    is not theoretical: this agent installed and ran `rembg` unprompted on the previous
+#    design, purely because it inferred a cutout was wanted — and the row/tween/reroll
+#    pipelines (`gen_set.run_gen_cli`, `reroll`, `interpolate.gen_interpolator`) call
+#    `generate_image` WITHOUT `transparent=True`, because their prompts already carry the
+#    run's key and `extract` does the matting later. Gating this half on "are we keying
+#    right now" therefore left every pipeline row unprotected: a prompt that says "flat
+#    magenta background" and nothing else is exactly the input that provoked the
+#    unasked-for segmentation in the first place. An alpha'd row would then reach
+#    `remove_chroma_background_ycbcr` with no chroma left to key.
+#
+#    The refusal is spelled out per tool class (segmentation, matting, alpha,
+#    checkerboard) and the reason is given — an agent that understands WHY the flat
+#    backdrop is wanted is far less likely to "improve" on it.
+#
+# 2. `_CHROMA_BACKDROP_TEMPLATE` — only when we know the key (`request.chroma_key`).
+#
+#    Naming a colour is only safe when it is THE colour that will be matted out. On the
+#    pipeline paths we do not know it: `prepare.py` picks the run's key per character
+#    (auto magenta/green from the base image) and writes it into each row prompt itself,
+#    while `generate_image`'s own `chroma_key` argument is just its "magenta" default
+#    there. Injecting that default would contradict a green run's prompt. So on those
+#    paths the caller's prompt stays the single source of the backdrop, and this adapter
+#    adds only piece 1.
+#
+# Written in English because agy's own tooling/skill vocabulary is English.
+_NO_SELF_MATTE_INSTRUCTION = (
+    "BACKGROUND HANDLING — this is mandatory on every image you save here:\n"
+    "  - The saved PNG must be OPAQUE. Do NOT remove the background. Do NOT run rembg, "
+    "any background-removal, segmentation, matting or cutout tool. Do NOT produce an "
+    "alpha channel, and do NOT draw a checkerboard pattern to imply transparency.\n"
+    "  - The caller removes the background itself, downstream, with its own matte. A "
+    "pre-removed background, a soft/blended subject edge, or a saved alpha channel "
+    "breaks that step. Hand back the flat, opaque, fully-rendered image."
+)
+_CHROMA_BACKDROP_TEMPLATE = (
+    "  - Place the subject on a COMPLETELY FLAT, SOLID, UNIFORM {name} chroma-key "
+    "backdrop, hex {hex}. One single colour across every background pixel: no gradient, "
+    "no vignette, no shading, no lighting falloff, no texture, no drop shadow on the "
+    "backdrop, no scenery, no floor line, no horizon. Flat {hex} behind the subject, "
+    "nothing else — that exact colour is what the caller keys out."
+)
+
+# Response parsing. `response` is prose written by an agent, not a schema, so every
+# shape observed or plausibly emitted gets its own pattern and they are all tried;
+# the caller then keeps whichever candidate actually exists on disk. Observed
+# 2026-09-12: a bare absolute path on its own line. Documented elsewhere in agy's
+# output: a markdown `[name](file:///...)` link and a `**File:**`/`**Folder:**`
+# detail pair. None of these is a "fallback" for another — they are alternate
+# renderings of the same fact, so all are canonical.
+_MD_LINK_RE = re.compile(r"\[[^\]\n]*\]\(\s*<?([^)>\s]+)>?\s*\)")
+_FILE_URL_RE = re.compile(r"file://[^\s)\]\"'<>]+")
+_FILE_DETAIL_RE = re.compile(r"\*\*File:\*\*\s*`?([^\n`*]+?)`?\s*(?:\n|$)")
+_FOLDER_DETAIL_RE = re.compile(r"\*\*Folder:\*\*\s*`?([^\n`*]+?)`?\s*(?:\n|$)")
+# A bare path on its own line — Windows drive-letter or POSIX absolute, image suffix.
+_BARE_PATH_RE = re.compile(
+    r"(?mi)^\s*`?((?:[A-Za-z]:[\\/]|/)[^\n`*]+?\.(?:png|webp|jpe?g))`?\s*$"
+)
+_IMAGE_SUFFIXES = (".png", ".webp", ".jpg", ".jpeg")
+
+
+def _from_file_url(token: str) -> str:
+    """Decode a `file://` URL to a filesystem path (percent-decoded, drive-aware).
+
+    `file:///D:/x/image%20test/boy.png` -> `D:/x/image test/boy.png`. urlparse
+    leaves the Windows form as `/D:/...`, so the leading slash is dropped when a
+    drive letter follows it.
+    """
+    parsed = urlparse(token)
+    path = unquote(parsed.path)
+    if re.match(r"^/[A-Za-z]:", path):
+        path = path[1:]
+    return path
+
+
+def reported_paths(response: str) -> list[str]:
+    """Every filesystem path the agent's prose claims, in first-seen order.
+
+    Order is stable and duplicate-free so the caller's choice is deterministic
+    and the list can be published in the report as what the agent said.
+    """
+    found: list[str] = []
+
+    def add(token: str) -> None:
+        token = token.strip().strip("`").strip()
+        if not token:
+            return
+        if token.lower().startswith("file://"):
+            token = _from_file_url(token)
+        if not token.lower().endswith(_IMAGE_SUFFIXES):
+            return
+        if token not in found:
+            found.append(token)
+
+    for match in _MD_LINK_RE.finditer(response):
+        add(match.group(1))
+    for match in _FILE_URL_RE.finditer(response):
+        add(match.group(0))
+    for match in _BARE_PATH_RE.finditer(response):
+        add(match.group(1))
+    # A `**File:**` detail names a bare filename and the `**Folder:**` beside it in the
+    # SAME details block supplies its directory. Pair them by position, never by cross
+    # product: a response listing two saves must not be able to produce file A under
+    # folder B. That is not cosmetic — a wrong pairing that happens to name some real
+    # file inside an `--add-dir` workspace would be copied out and published, and
+    # `verify_png` only proves a file is a PNG, not that it is the right PNG.
+    #
+    # "Beside it" = nearest `**Folder:**` AFTER the `**File:**` (agy's details blocks
+    # list File then Folder), falling back to the nearest one BEFORE it so a
+    # Folder-then-File block still pairs correctly. Only those two candidates are ever
+    # considered, so a distant unrelated block can never be joined on.
+    folders = [
+        (match.start(), match.group(1).strip().strip("`"))
+        for match in _FOLDER_DETAIL_RE.finditer(response)
+    ]
+    for match in _FILE_DETAIL_RE.finditer(response):
+        name = match.group(1).strip().strip("`")
+        add(name)  # already absolute, or resolvable against the workdir
+        if not name or Path(name).is_absolute():
+            continue
+        after = next((text for start, text in folders if start > match.start()), None)
+        before = next(
+            (text for start, text in reversed(folders) if start < match.start()), None
+        )
+        for folder in (after, before):
+            if folder:
+                add(str(Path(folder) / name))
+                break
+    return found
+
+
+def _background_instruction(key: str | None) -> str:
+    """The background block for one run: the never-self-matte rule, plus the key if known.
+
+    An unknown key fails here rather than reaching the model: generating against a
+    colour the matte does not know is a guaranteed 0.0%-keyed failure two minutes
+    later, and a named error now is cheaper than a mystery then.
+    """
+    if key is None:
+        return _NO_SELF_MATTE_INSTRUCTION
+    hex_value = _KEY_HEX.get(key)
+    if hex_value is None:
+        raise SystemExit(
+            f"agy-gen: unknown chroma key {key!r}; expected one of {', '.join(sorted(_KEY_HEX))}"
+        )
+    return (
+        _NO_SELF_MATTE_INSTRUCTION
+        + "\n"
+        + _CHROMA_BACKDROP_TEMPLATE.format(name=key, hex=hex_value)
+    )
+
+
+def _build_prompt(
+    user_prompt: str,
+    destination: Path,
+    refs: list[Path],
+    *,
+    chroma_key: str | None = None,
+) -> str:
+    """Wrap the caller's prompt in the agy transport contract.
+
+    The caller's prompt is the SSoT and is passed through verbatim; everything
+    around it (the exact destination path, the reference-image list, the chroma
+    backdrop instruction) is this adapter's transport, owned in exactly one place.
+
+    The "never matte it yourself" rule goes in on EVERY run, keyed or not — it is an
+    invariant of this adapter, and the row/tween/reroll pipelines (which never pass
+    `transparent=True`) need it most. `chroma_key` adds the second, colour-naming half
+    and is set only when the orchestrator is about to matte that exact key out; when it
+    is None the backdrop colour stays entirely the caller's prompt's business, so a
+    sprite row that already carries its run's own key gets no contradictory second one.
+    """
+    lines = [
+        "Generate exactly ONE image with a real generative image model.",
+        "Do not draw it procedurally with code (PIL/ImageMagick/SVG) — that is not a generation.",
+        "",
+    ]
+    if refs:
+        # agy's print mode has no image-input flag (`-i` is `--prompt-interactive`,
+        # not an image). References ride the workspace instead: each reference's
+        # directory is passed with `--add-dir` and the absolute paths are named
+        # here. Verified 2026-09-12 — the agent opened a PNG from an added dir and
+        # described its contents correctly, so this is a real vision input, not a
+        # hopeful instruction.
+        lines.append(
+            "First OPEN AND LOOK AT these reference images and follow them for identity, "
+            "style, palette and framing:"
+        )
+        lines += [f"  - {ref}" for ref in refs]
+        lines.append("")
+    lines += ["Prompt:", user_prompt.strip(), ""]
+    lines += [_background_instruction(chroma_key), ""]
+    lines += [
+        "Save the final PNG at exactly this absolute path, overwriting anything already there:",
+        str(destination),
+        "",
+        "Write no other copy of the image, and do not move or rename it afterwards.",
+        "When you are done, reply with that absolute path and nothing else.",
+    ]
+    return "\n".join(lines)
+
+
+def _parse_envelope(stdout: str) -> dict:
+    """Parse `--output-format json`'s single JSON object off stdout.
+
+    Tolerates leading/trailing noise (a banner or an update notice) by scanning
+    lines for the first one that parses as a JSON object carrying `status`, then
+    falling back to the whole stream. A stream with no such object is a transport
+    failure and says so with the head of what was actually printed.
+    """
+    text = (stdout or "").strip()
+    if text:
+        try:
+            whole = json.loads(text)
+            if isinstance(whole, dict):
+                return whole
+        except json.JSONDecodeError:
+            pass
+        for line in text.splitlines():
+            line = line.strip()
+            if not line.startswith("{"):
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(event, dict) and "status" in event:
+                return event
+    head = "\n".join(text.splitlines()[:20]) or "(nothing on stdout)"
+    raise SystemExit(
+        "agy-gen: agy printed no JSON envelope despite --output-format json — "
+        f"refusing to guess what happened:\n{head}"
+    )
+
+
+def _resolve_candidate(token: str, workdir: Path) -> Path | None:
+    """Fully resolved path for one reported token, or None if it cannot be resolved.
+
+    A relative token is workdir-relative. `resolve()` is what makes the containment
+    check in `_within` meaningful: it normalises away `..` traversal AND follows
+    symlinks, so a link sitting inside the workspace that points at an external file
+    is judged by its real target, not by where the link happens to live.
+    """
+    path = Path(token).expanduser()
+    if not path.is_absolute():
+        path = workdir / path
+    try:
+        return path.resolve()
+    except OSError:
+        # A malformed token (illegal characters, a too-long path) is not a candidate.
+        return None
+
+
+def _within(path: Path, roots: tuple[Path, ...]) -> bool:
+    """Is an already-resolved path inside one of these already-resolved roots?"""
+    return any(path == root or path.is_relative_to(root) for root in roots)
+
+
+class AgyProvider:
+    """Generate one image through the Antigravity CLI (`agy`)."""
+
+    name = "agy"
+    # See the module docstring: agy's model cannot return alpha, so the adapter has it
+    # paint a flat key backdrop and sprite-gen's own `key_transparent` mattes that out.
+    # Deliberately NOT `native` — letting the agent segment for us worked once and is
+    # non-deterministic by construction.
+    transparency = TRANSPARENCY_CHROMA
+
+    def generate(self, request: GenRequest, workdir: Path) -> ProviderRun:
+        destination = Path(request.raw).expanduser().resolve()
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        # Unlink first so "the file exists afterwards" is proof THIS run wrote it.
+        # `gen` normally hands out a fresh temp workdir, but `--workdir` lets a
+        # caller reuse one, and a stale raw.png from an earlier attempt would
+        # otherwise be published as a success.
+        destination.unlink(missing_ok=True)
+
+        refs = [Path(ref).expanduser().resolve() for ref in request.refs]
+        for ref in refs:
+            if not ref.is_file():
+                raise SystemExit(f"agy-gen: reference image not found: {ref}")
+
+        # One --add-dir per distinct directory the agent must touch: the output
+        # directory plus every reference's directory (deduplicated, stable order).
+        add_dirs: list[str] = []
+        for directory in (destination.parent, *(ref.parent for ref in refs)):
+            text = str(directory)
+            if text not in add_dirs:
+                add_dirs.append(text)
+
+        # The boundary the recovery path will accept a file from. Deliberately NARROWER
+        # than `add_dirs`: `--add-dir` is a read+write grant covering the reference
+        # directories too, whereas these are the only two places agy is TOLD to write
+        # (the output directory, and the working directory it is launched in, which is
+        # where a relative save lands). A generated image appearing anywhere else is not
+        # something to trust and copy — it is something to refuse and report.
+        write_roots: tuple[Path, ...] = tuple(
+            dict.fromkeys((destination.parent.resolve(), Path(workdir).expanduser().resolve()))
+        )
+
+        if request.native_alpha:
+            # Unreachable through `generate_image` (`resolve_transparency_strategy`
+            # refuses `--alpha-mode native` on a chroma provider), so this guards a
+            # direct caller rather than the CLI — and it fails before the model runs,
+            # exactly like grok's equivalent refusal, instead of returning an opaque
+            # PNG that something downstream would have to notice.
+            raise SystemExit(
+                "agy-gen: agy cannot return an alpha channel; it generates on a chroma key "
+                "and sprite-gen mattes it out (use --alpha-mode chroma or another provider)"
+            )
+
+        prompt = _build_prompt(
+            request.prompt, destination, refs, chroma_key=request.chroma_key
+        )
+        cmd = [provider_binary("agy"), "--output-format", "json"]
+        for directory in add_dirs:
+            cmd += ["--add-dir", directory]
+        if request.model:
+            cmd += ["--model", request.model]
+        cmd += ["-p", prompt]
+
+        started = time.monotonic()
+        # A headless provider must not inherit parent orchestration identity or
+        # lifecycle controls (see base.provider_subprocess_env).
+        try:
+            completed = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                env=provider_subprocess_env(),
+                cwd=str(workdir),
+                timeout=AGY_GEN_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired:
+            raise GenTimeoutError(
+                f"agy-gen: no completion within {AGY_GEN_TIMEOUT_SECONDS}s — child killed "
+                "(gen-timeout). A normal turn is ~63s (2026-09-12 실측), so a run that never "
+                "returns at all usually means agy is waiting on a tool-approval prompt — set "
+                "Tool Permission to always-proceed in `agy` -> /config."
+            ) from None
+        elapsed = time.monotonic() - started
+        stdout = completed.stdout or ""
+
+        if completed.returncode != 0:
+            tail = (completed.stderr or "").strip().splitlines()[-20:]
+            detail = "\n".join(tail).strip() or (
+                "\n".join(stdout.splitlines()[:20]) or "(no error detail on stdout/stderr)"
+            )
+            raise SystemExit(f"agy-gen: agy exited {completed.returncode}\n{detail}")
+
+        envelope = _parse_envelope(stdout)
+        status = envelope.get("status")
+        response = str(envelope.get("response") or "")
+        if status != "SUCCESS":
+            raise SystemExit(
+                f"agy-gen: agy reported status={status!r} (expected 'SUCCESS'); no image published.\n"
+                f"  conversation_id: {envelope.get('conversation_id')}\n"
+                f"  response: {response.strip()[:800] or '(empty)'}"
+            )
+
+        claimed = reported_paths(response)
+        # The instructed destination wins when it was actually written; otherwise
+        # the reported paths are the recovery route. Either way the choice is made
+        # by what is on disk, never by what the agent said (No Silent Fallback).
+        source: Path | None = destination if destination.is_file() else None
+        recovered_from: str | None = None
+        rejected: list[str] = []
+        if source is None:
+            # Recovery reads paths out of agent-written prose, so every candidate is
+            # untrusted input and gets bounded before anything is copied. Two rules:
+            #
+            #   Containment — the resolved path must be inside `write_roots` (the
+            #   output directory and the working directory: the only two places agy is
+            #   told to write). Anything else is refused, whatever it is. Without this,
+            #   an absolute path, a `~/...` token or a `../../` traversal in the prose
+            #   could name any readable file on the machine and it would be copied in
+            #   and published as the sprite — `verify_png` proves a file is a PNG, never
+            #   that it is the right PNG. Because `_resolve_candidate` resolves first,
+            #   a symlink inside the workspace pointing outside it is judged by its
+            #   target and refused too.
+            #
+            #   Not an input — the reference images are deliberately NOT part of the
+            #   boundary even though their directories are in `--add-dir`: those are
+            #   read-only inputs, and republishing an identity ref as this run's
+            #   generation is exactly the silent wrong-file outcome being prevented. A
+            #   ref that happens to sit inside the workdir is skipped by name.
+            ref_set = {ref.resolve() for ref in refs}
+            for token in claimed:
+                candidate = _resolve_candidate(token, workdir)
+                if candidate is None:
+                    continue
+                if not _within(candidate, write_roots):
+                    rejected.append(f"{token}  (outside the workspace: {candidate})")
+                    continue
+                if candidate in ref_set:
+                    rejected.append(f"{token}  (that is a reference image, not the output)")
+                    continue
+                if candidate.is_file():
+                    source, recovered_from = candidate, token
+                    break
+        if source is None:
+            rendered = "\n".join(f"  - {token}" for token in claimed) or "  (none)"
+            refusals = (
+                "\n  refused before copying:\n" + "\n".join(f"  - {line}" for line in rejected)
+                if rejected
+                else ""
+            )
+            raise SystemExit(
+                "agy-gen: agy reported SUCCESS but no usable generated image exists on disk — "
+                "refusing to claim success.\n"
+                f"  instructed destination (not written): {destination}\n"
+                f"  writes are only accepted under: {', '.join(str(root) for root in write_roots)}\n"
+                f"  paths parsed out of the response:\n{rendered}{refusals}\n"
+                f"  response: {response.strip()[:800] or '(empty)'}"
+            )
+        if source != destination:
+            shutil.copyfile(source, destination)
+
+        # Truth is the decoded bytes, not the agent's report.
+        verify_png(destination)
+
+        usage = envelope.get("usage")
+        return ProviderRun(
+            provider=self.name,
+            elapsed_seconds=elapsed,
+            model=request.model,
+            # agy's conversation id is the closest analogue to codex's rollout
+            # session id — same role (resume/inspect the turn), so it rides the
+            # dedicated field as well as `extra`.
+            session_id=envelope.get("conversation_id"),
+            extra={
+                "transport": "agy-cli",
+                "conversation_id": envelope.get("conversation_id"),
+                "num_turns": envelope.get("num_turns"),
+                "usage": usage if isinstance(usage, dict) else None,
+                # agy's own wall clock for the turn, next to our measured `elapsed_seconds`.
+                "agy_duration_seconds": envelope.get("duration_seconds"),
+                "reported_paths": claimed,
+                # Non-None only when the agent ignored the instructed destination and
+                # we recovered the image from a path it reported — visible, not silent.
+                "recovered_from": recovered_from,
+                # Which backdrop this run asked for, next to the `chroma` stats the
+                # orchestrator publishes for the matte that consumed it.
+                "chroma_key_requested": request.chroma_key,
+                "refs": [str(ref) for ref in refs],
+            },
+        )

--- a/sprite_gen/gen/base.py
+++ b/sprite_gen/gen/base.py
@@ -104,6 +104,19 @@ class GenRequest:
     # legal for a provider whose `transparency` is `native`; the orchestrator gates
     # it and the provider carries the request into its transport prompt.
     native_alpha: bool = False
+    # The chroma key (`chroma.KEYS` name) the orchestrator will matte out after this
+    # generation, or None when the run is not keying. The exact mirror of
+    # `native_alpha` for the other strategy: the orchestrator decides the strategy,
+    # and the provider carries whatever that strategy needs into its transport prompt.
+    #
+    # Only a provider that can act on its own initiative needs to read this. grok is a
+    # bare image API — it paints exactly the background the caller's prompt describes,
+    # so the sprite-row prompts carry the key themselves and the adapter stays out of it
+    # (unchanged). An agent CLI does not behave that way: given no instruction it picks
+    # its own background, and measured 2026-09-12 it will even segment the subject out
+    # unasked. `agy_provider` therefore states the key in its prompt — and it must be
+    # THIS key, not a guess, or the painted background and the matte disagree.
+    chroma_key: str | None = None
 
 
 @dataclass

--- a/sprite_gen/gen/gen_set.py
+++ b/sprite_gen/gen/gen_set.py
@@ -244,9 +244,12 @@ def run_set(
 def add_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--run-dir", required=True, type=Path, help="a prepared run (sprite-request.json, prompts/, references/layout-guides/)")
     parser.add_argument("--states", help="comma list; default = every non-mirrored state in the request")
-    # Choices come from the gen module's PROVIDERS tuple (the SSoT) so a new adapter
-    # is selectable here the moment it is registered — no second provider list to drift.
-    parser.add_argument("--provider", choices=gen_mod.PROVIDERS, help="honoured verbatim; default resolves like `gen` (env > codex, observable failover)")
+    # ROW_PROVIDERS, not PROVIDERS: every item here is a whole multi-pose row generated
+    # from one `prompts/<state>.txt`, and agy could not produce one at all — 2026-09-12
+    # 실측, a 4-pose prompt hit agy's own 5-minute timeout unfinished, burned ~240k
+    # tokens and wrote no file. Sourced from the gen module so the row-capability list
+    # lives in exactly one place (see gen/__init__.py for the full measurement).
+    parser.add_argument("--provider", choices=gen_mod.ROW_PROVIDERS, help="honoured verbatim; default resolves like `gen` (env > codex, observable failover); row generation excludes agy")
     parser.add_argument("--model")
     parser.add_argument("--concurrency", type=int, default=DEFAULT_CONCURRENCY, help=f"rows generated at once (default {DEFAULT_CONCURRENCY})")
     parser.add_argument("--force", action="store_true", help="regenerate rows that already exist")

--- a/sprite_gen/gen/gen_set.py
+++ b/sprite_gen/gen/gen_set.py
@@ -244,7 +244,9 @@ def run_set(
 def add_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--run-dir", required=True, type=Path, help="a prepared run (sprite-request.json, prompts/, references/layout-guides/)")
     parser.add_argument("--states", help="comma list; default = every non-mirrored state in the request")
-    parser.add_argument("--provider", choices=("codex", "grok"), help="honoured verbatim; default resolves like `gen` (env > codex, observable failover)")
+    # Choices come from the gen module's PROVIDERS tuple (the SSoT) so a new adapter
+    # is selectable here the moment it is registered — no second provider list to drift.
+    parser.add_argument("--provider", choices=gen_mod.PROVIDERS, help="honoured verbatim; default resolves like `gen` (env > codex, observable failover)")
     parser.add_argument("--model")
     parser.add_argument("--concurrency", type=int, default=DEFAULT_CONCURRENCY, help=f"rows generated at once (default {DEFAULT_CONCURRENCY})")
     parser.add_argument("--force", action="store_true", help="regenerate rows that already exist")

--- a/sprite_gen/gen/generate_image.py
+++ b/sprite_gen/gen/generate_image.py
@@ -2,7 +2,7 @@
 """Deprecated shim — image generation now lives in `sprite_gen.gen`.
 
 This module previously stood in as a desktop-only placeholder during the package
-split. Provider-backed generation (codex `image_gen`, grok Imagine) is now a
+split. Provider-backed generation (codex `image_gen`, grok Imagine, Antigravity `agy`) is now a
 first-class engine module: `sprite_gen.gen` / CLI `sprite-gen gen`. Keeping two
 generation surfaces would violate SSoT, so this shim redirects and fails loudly
 if called directly.
@@ -14,5 +14,5 @@ from __future__ import annotations
 def run(**_kwargs: object) -> int:
     raise SystemExit(
         "sprite_gen.gen.generate_image is retired — use `sprite_gen.gen` "
-        "(CLI: `sprite-gen gen --provider codex|grok --prompt ... --out ...`)"
+        "(CLI: `sprite-gen gen --provider codex|grok|agy --prompt ... --out ...`)"
     )

--- a/sprite_gen/serve/curator/src/gen-trigger.js
+++ b/sprite_gen/serve/curator/src/gen-trigger.js
@@ -9,18 +9,26 @@
 // 다른 제스처(Alt클릭 모델 선택 등)를 만들지 않는다 — 회귀 2026-07-19 maintainer
 // "보간은 클릭하면 모델선택이고 리롤은 alt클릭이고 다 지멋대로".
 
+// 서버의 sprite_gen.gen.PROVIDERS 와 같은 집합 (최종 검증은 언제나 서버).
+// `row: false` = 다중 포즈 행 한 장을 통째로 만들지 못하는 provider — 서버의
+// ROW_PROVIDERS 와 같은 구분이다. agy 는 4포즈 프롬프트가 자체 5분 타임아웃을
+// 미완료로 넘기고 ~240k 토큰을 쓰고 파일을 남기지 않았다 (2026-09-12 실측), 반면
+// 단일 피사체는 ~27~65초에 끝난다. 그래서 보간(프레임 1장)에는 뜨고 리롤(행 1줄)에는
+// 뜨지 않는다. 목록 마지막인 이유는 셋 중 가장 느려서다.
 const GEN_PROVIDERS = [
-  { value: "codex", label: "GPT" },
-  { value: "grok", label: "Grok" },
-  // 서버의 sprite_gen.gen.PROVIDERS 와 같은 집합 (서버가 최종 검증한다). agy 는
-  // 한 턴이 60~130초라 다른 둘보다 눈에 띄게 느리다 — 그래서 목록 마지막.
-  { value: "agy", label: "Antigravity" },
+  { value: "codex", label: "GPT", row: true },
+  { value: "grok", label: "Grok", row: true },
+  { value: "agy", label: "Antigravity", row: false },
 ];
 
-// 공용 모델 선택 위젯 — 표기/순서/기본값(codex)의 유일한 자리
-function makeProviderSelect() {
+// 공용 모델 선택 위젯 — 표기/순서/기본값(codex)의 유일한 자리.
+// `{ rowCapableOnly: true }` 를 주면 행 생성 트리거(리롤)용으로 좁힌다: 눌러봐야
+// 서버가 400 으로 거절할 선택지를 애초에 보여주지 않는다.
+function makeProviderSelect(options) {
+  const rowCapableOnly = Boolean(options && options.rowCapableOnly);
   const sel = document.createElement("select");
   for (const p of GEN_PROVIDERS) {
+    if (rowCapableOnly && !p.row) continue;
     const opt = document.createElement("option");
     opt.value = p.value;
     opt.textContent = p.label;

--- a/sprite_gen/serve/curator/src/gen-trigger.js
+++ b/sprite_gen/serve/curator/src/gen-trigger.js
@@ -12,6 +12,9 @@
 const GEN_PROVIDERS = [
   { value: "codex", label: "GPT" },
   { value: "grok", label: "Grok" },
+  // 서버의 sprite_gen.gen.PROVIDERS 와 같은 집합 (서버가 최종 검증한다). agy 는
+  // 한 턴이 60~130초라 다른 둘보다 눈에 띄게 느리다 — 그래서 목록 마지막.
+  { value: "agy", label: "Antigravity" },
 ];
 
 // 공용 모델 선택 위젯 — 표기/순서/기본값(codex)의 유일한 자리

--- a/sprite_gen/serve/curator/src/row-controls.js
+++ b/sprite_gen/serve/curator/src/row-controls.js
@@ -48,7 +48,8 @@ function makeRerollButton(stateName) {
   const pop = document.createElement("div");
   pop.className = "gen-pop";
   pop.hidden = true;
-  const providerSel = makeProviderSelect();
+  // 리롤 = 다중 포즈 행 한 장 재생성이라 행을 만들 수 있는 provider 만 (gen-trigger.js).
+  const providerSel = makeProviderSelect({ rowCapableOnly: true });
   pop.appendChild(providerSel);
   const go = document.createElement("button");
   go.type = "button";

--- a/sprite_gen/serve/serve_curation.py
+++ b/sprite_gen/serve/serve_curation.py
@@ -64,6 +64,7 @@ from sprite_gen.spec.layout import frames_dir_rel, raw_rel, row_frame_rel, row_o
 from sprite_gen.spec.runio import load_request, publish_guard, read_guard, write_request
 from sprite_gen._modules import qualified
 from sprite_gen.gen import PROVIDERS as GEN_PROVIDERS
+from sprite_gen.gen import ROW_PROVIDERS as GEN_ROW_PROVIDERS
 
 # The SPA assets are package data (declared in pyproject's `package-data`), so the one
 # path that finds them is relative to this module — the same place in a repo checkout and
@@ -1514,10 +1515,12 @@ class CurationHandler(BaseHTTPRequestHandler):
                     self._send_json({"error": f"unknown state: {state}"}, 400)
                     return
                 provider = str(payload.get("provider") or "codex")
-                # The accepted set is `sprite_gen.gen.PROVIDERS` (the SSoT) — a view
-                # button must not carry its own copy of the provider list.
-                if provider not in GEN_PROVIDERS:
-                    self._send_json({"error": f"unknown provider: {provider}"}, 400)
+                # Reroll regenerates a whole multi-pose ROW, so the accepted set is
+                # ROW_PROVIDERS, not PROVIDERS (agy cannot compose a row — see
+                # sprite_gen.gen). `reroll_state` re-checks; this just answers 400
+                # instead of 500 and never starts the subprocess.
+                if provider not in GEN_ROW_PROVIDERS:
+                    self._send_json({"error": f"provider cannot generate a row: {provider}"}, 400)
                     return
                 result = run_reroll(self.run_dir, state, provider)
                 self._send_json(result, 200 if result["ok"] else 500)

--- a/sprite_gen/serve/serve_curation.py
+++ b/sprite_gen/serve/serve_curation.py
@@ -63,6 +63,7 @@ from sprite_gen.frames.extract import heal_run, load_consistent_frames_manifest
 from sprite_gen.spec.layout import frames_dir_rel, raw_rel, row_frame_rel, row_orig_rel, state_frame_total
 from sprite_gen.spec.runio import load_request, publish_guard, read_guard, write_request
 from sprite_gen._modules import qualified
+from sprite_gen.gen import PROVIDERS as GEN_PROVIDERS
 
 # The SPA assets are package data (declared in pyproject's `package-data`), so the one
 # path that finds them is relative to this module — the same place in a repo checkout and
@@ -1496,7 +1497,9 @@ class CurationHandler(BaseHTTPRequestHandler):
                     self._send_json({"error": f"t must be inside (0, 1): {t_value}"}, 400)
                     return
                 provider = str(payload.get("provider") or "codex")
-                if provider not in ("codex", "grok"):
+                # The accepted set is `sprite_gen.gen.PROVIDERS` (the SSoT) — a view
+                # button must not carry its own copy of the provider list.
+                if provider not in GEN_PROVIDERS:
                     self._send_json({"error": f"unknown provider: {provider}"}, 400)
                     return
                 result = run_interpolate(self.run_dir, state, index_a, index_b,
@@ -1511,7 +1514,9 @@ class CurationHandler(BaseHTTPRequestHandler):
                     self._send_json({"error": f"unknown state: {state}"}, 400)
                     return
                 provider = str(payload.get("provider") or "codex")
-                if provider not in ("codex", "grok"):
+                # The accepted set is `sprite_gen.gen.PROVIDERS` (the SSoT) — a view
+                # button must not carry its own copy of the provider list.
+                if provider not in GEN_PROVIDERS:
                     self._send_json({"error": f"unknown provider: {provider}"}, 400)
                     return
                 result = run_reroll(self.run_dir, state, provider)

--- a/sprite_gen/workflow/access.py
+++ b/sprite_gen/workflow/access.py
@@ -27,6 +27,19 @@ def probe_access(provider: str, *, video: bool = False) -> dict:
         if "chatgpt" not in output:
             return {**result, "reason": "login succeeded but ChatGPT subscription authentication was not identified"}
         return {**result, "login": "ready"}
+    if provider == "agy":
+        # Antigravity signs in through a Google AI Pro account inside the CLI and
+        # exposes no offline status subcommand (`agy --help`, 2026-09-12: agent /
+        # models / mcp / plugin / update — nothing like `login status`). Everything
+        # that would actually prove the session works (`agy models`, a probe turn)
+        # is a network round trip on the user's quota, which a read-only guide must
+        # not spend. So presence on PATH is the only thing checked and the login
+        # stays "unknown" — which is what makes the guide ask the user to confirm
+        # the subscription rather than assert it.
+        if shutil.which("agy") is None:
+            return {**result, "login": "unavailable", "reason": "agy (Antigravity) CLI is not installed"}
+        return {**result, "reason": "agy CLI is installed; Antigravity has no offline login check, "
+                                    "so confirm the Google AI Pro sign-in and image availability."}
     if provider != "grok":
         raise ValueError(f"unknown provider: {provider}")
     try:

--- a/sprite_gen/workflow/catalog.py
+++ b/sprite_gen/workflow/catalog.py
@@ -8,9 +8,13 @@ MOTION_METHODS = {
     "grok-video": {"label": "그록 영상", "provider": "grok", "doc": "docs/video-pipeline.md",
                    "steps": ["video-set"]},
 }
+# One label per provider, keyed by name — never zipped against PROVIDERS positionally.
+# `zip` truncates to the shorter side, so a newly registered provider with no label here
+# would have been dropped from the question silently; a dict lookup fails loudly instead.
+PROVIDER_LABELS = {"codex": "지피티", "grok": "그록", "agy": "안티그래비티"}
 FIELDS = {
-    "image_provider": {"options": dict(zip(PROVIDERS, ("지피티", "그록"))),
-                       "question": "이미지를 지피티로 만들까요, 그록으로 만들까요?"},
+    "image_provider": {"options": {name: PROVIDER_LABELS[name] for name in PROVIDERS},
+                       "question": "이미지를 지피티, 그록, 안티그래비티 중 무엇으로 만들까요?"},
     "motion_method": {"options": {k: v["label"] for k, v in MOTION_METHODS.items()},
                       "question": "동작을 그록 영상으로 만들까요, 지피티 이미지 스프라이트로 만들까요?"},
     "curation": {"options": {"open": "열기", "skip": "열지 않기"},

--- a/tests/gen/test_agy_provider.py
+++ b/tests/gen/test_agy_provider.py
@@ -546,3 +546,65 @@ def test_recovery_still_works_for_a_file_inside_the_workspace(tmp_path, spawn) -
     run = agy.AgyProvider().generate(GenRequest(prompt="p", raw=raw), work)
     assert raw.read_bytes() == _png_bytes()
     assert run.extra["recovered_from"]
+
+
+# --- row capability: agy is a single-image provider, not a row provider -------
+
+
+def _argparse_choices(add_arguments, flag: str = "--provider"):
+    """The literal `choices=` a command declares for `--provider`."""
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    add_arguments(parser)
+    action = next(a for a in parser._actions if flag in a.option_strings)
+    return tuple(action.choices)
+
+
+def test_agy_is_a_provider_but_not_a_row_provider() -> None:
+    assert "agy" in gen.PROVIDERS
+    assert "agy" not in gen.ROW_PROVIDERS
+    assert gen.ROW_PROVIDERS == ("codex", "grok")
+
+
+def test_the_standalone_gen_command_still_accepts_agy() -> None:
+    """agy is verified solid for one image per call — it must stay selectable here."""
+    assert "agy" in _argparse_choices(gen.add_arguments)
+
+
+def test_gen_set_refuses_agy_because_a_row_is_multi_pose() -> None:
+    """Regression guard: 2026-09-12 실측 — a 4-pose prompt hit agy's own 5-minute
+    timeout unfinished, spent ~240k tokens and wrote no file. Nothing may silently
+    re-widen this without a fresh measurement."""
+    from sprite_gen.gen import gen_set
+
+    choices = _argparse_choices(gen_set.add_arguments)
+    assert "agy" not in choices
+    assert "codex" in choices and "grok" in choices
+
+
+def test_reroll_refuses_agy_at_the_cli_and_in_the_function() -> None:
+    """reroll regenerates the whole row from the same `prompts/<state>.txt` as gen-set.
+
+    The function-level guard matters because the curation view (`serve_curation`)
+    calls `reroll_state` directly, never through argparse.
+    """
+    from sprite_gen.effects import reroll
+
+    parser = reroll._build_parser()
+    action = next(a for a in parser._actions if "--provider" in a.option_strings)
+    assert "agy" not in tuple(action.choices)
+
+    with pytest.raises(SystemExit, match="cannot generate a multi-pose row"):
+        reroll.reroll_state(Path("nonexistent-run"), "idle", provider="agy")
+
+
+def test_interpolate_keeps_agy_because_it_draws_one_pose() -> None:
+    """`gen_interpolator`'s prompt asks for "exactly ONE full-body pose" — the shape
+    agy is verified good at, so this call site is deliberately NOT restricted."""
+    from sprite_gen.effects import interpolate
+
+    assert "agy" in interpolate.PROVIDERS
+    parser = interpolate._build_parser()
+    action = next(a for a in parser._actions if "--provider" in a.option_strings)
+    assert "agy" in tuple(action.choices)

--- a/tests/gen/test_agy_provider.py
+++ b/tests/gen/test_agy_provider.py
@@ -1,0 +1,548 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Antigravity (`agy`) provider contract, offline: no CLI, no Google account, no network.
+
+The live end-to-end run is exercised by hand on a machine with `agy` installed and
+signed in (see docs/gen.md). Here we lock the deterministic seams: the spawn shape,
+the JSON-envelope contract, the prose path parser, the "bytes on disk decide"
+publication rule, and the orchestrator wiring (registration + transparency strategy).
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from sprite_gen import gen
+from sprite_gen.gen import agy_provider as agy
+from sprite_gen.gen.base import (
+    TRANSPARENCY_CHROMA,
+    TRANSPARENCY_NATIVE,
+    GenRequest,
+    GenTimeoutError,
+)
+
+
+def _png_bytes(color=(10, 200, 40, 255), size=(4, 4)) -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGBA", size, color).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _envelope(response: str, *, status: str = "SUCCESS") -> str:
+    return json.dumps(
+        {
+            "conversation_id": "479d0f29-6a7b-4250-bb21-4888554201b6",
+            "status": status,
+            "response": response,
+            "duration_seconds": 62.96,
+            "num_turns": 1,
+            "usage": {"input_tokens": 77463, "output_tokens": 3715, "total_tokens": 81178},
+        }
+    )
+
+
+class _Completed:
+    def __init__(self, stdout: str, *, returncode: int = 0, stderr: str = "") -> None:
+        self.stdout = stdout
+        self.stderr = stderr
+        self.returncode = returncode
+
+
+@pytest.fixture
+def spawn(monkeypatch):
+    """Stand in for `agy`. `state["writes"]` decides what lands on disk."""
+    state: dict = {"cmd": None, "kwargs": None, "writes": [], "stdout": None, "raise": None}
+
+    def fake_run(cmd, **kwargs):
+        state["cmd"] = cmd
+        state["kwargs"] = kwargs
+        if state["raise"] is not None:
+            raise state["raise"]
+        for path, data in state["writes"]:
+            Path(path).parent.mkdir(parents=True, exist_ok=True)
+            Path(path).write_bytes(data)
+        return _Completed(state["stdout"] or _envelope("done"))
+
+    monkeypatch.setattr(agy.subprocess, "run", fake_run)
+    return state
+
+
+# --- registration and strategy ------------------------------------------------
+
+
+def test_agy_is_a_registered_provider_and_builds() -> None:
+    assert "agy" in gen.PROVIDERS
+    backend = gen._make_provider("agy", keep_session=False)
+    assert isinstance(backend, agy.AgyProvider)
+    assert backend.name == "agy"
+
+
+def test_transparency_is_chroma_so_sprite_gen_owns_the_matte() -> None:
+    """agy cannot return alpha; `key_transparent` — our tested keyer — makes it.
+
+    The rejected alternative was `native`, letting the agent run rembg itself. It
+    worked once and is non-deterministic by construction, so the declaration routes
+    the raw PNG through sprite-gen's one extraction path instead.
+    """
+    backend = agy.AgyProvider()
+    assert backend.transparency == TRANSPARENCY_CHROMA
+    assert gen.resolve_transparency_strategy(backend, gen.ALPHA_MODE_AUTO) == (
+        TRANSPARENCY_CHROMA,
+        gen.STRATEGY_SOURCE_PROVIDER,
+    )
+    # refs change nothing: the step-down exists to avoid unreliable native alpha,
+    # and there is no native alpha here to step down from.
+    assert gen.resolve_transparency_strategy(
+        backend, gen.ALPHA_MODE_AUTO, refs=[Path("ref.png")]
+    ) == (TRANSPARENCY_CHROMA, gen.STRATEGY_SOURCE_PROVIDER)
+
+
+def test_alpha_mode_native_is_refused_before_any_model_call() -> None:
+    with pytest.raises(SystemExit, match="not a capability of provider 'agy'"):
+        gen.resolve_transparency_strategy(agy.AgyProvider(), TRANSPARENCY_NATIVE)
+
+
+def test_a_direct_native_alpha_request_is_refused_without_spawning(tmp_path, spawn) -> None:
+    with pytest.raises(SystemExit, match="cannot return an alpha channel"):
+        agy.AgyProvider().generate(
+            GenRequest(prompt="p", raw=tmp_path / "raw.png", native_alpha=True), tmp_path
+        )
+    assert spawn["cmd"] is None
+
+
+# --- spawn shape --------------------------------------------------------------
+
+
+def test_spawn_shape_names_the_destination_and_adds_its_directory(tmp_path, spawn) -> None:
+    raw = tmp_path / "work" / "raw.png"
+    spawn["writes"] = [(raw, _png_bytes())]
+    run = agy.AgyProvider().generate(
+        GenRequest(prompt="a red apple", raw=raw, model="some-model"), tmp_path
+    )
+
+    cmd = spawn["cmd"]
+    # `provider_binary` resolves PATH/PATHEXT shims, so the argv[0] is a real path on a
+    # machine that has agy installed and the bare name on one that does not.
+    assert "agy" in Path(cmd[0]).stem.lower()
+    assert "--output-format" in cmd and cmd[cmd.index("--output-format") + 1] == "json"
+    assert cmd[cmd.index("--add-dir") + 1] == str(raw.parent)
+    assert cmd[cmd.index("--model") + 1] == "some-model"
+    prompt = cmd[cmd.index("-p") + 1]
+    assert str(raw) in prompt, "the exact destination is stated in the prompt"
+    assert "a red apple" in prompt, "the caller's prompt is passed through verbatim"
+    # The never-self-matte rule rides every run (see the non-transparent test below);
+    # only the colour-naming half is conditional, and no key was requested here.
+    assert "Do NOT run rembg" in prompt
+    assert "chroma-key backdrop" not in prompt
+    assert spawn["kwargs"]["timeout"] == agy.AGY_GEN_TIMEOUT_SECONDS
+    assert spawn["kwargs"]["cwd"] == str(tmp_path)
+    assert run.provider == "agy" and run.model == "some-model"
+
+
+@pytest.mark.parametrize("key, hex_value", [("magenta", "#FF00FF"), ("green", "#00FF00")])
+def test_chroma_run_demands_a_flat_key_backdrop_and_forbids_self_matting(
+    tmp_path, spawn, key, hex_value
+) -> None:
+    raw = tmp_path / "raw.png"
+    spawn["writes"] = [(raw, _png_bytes())]
+    agy.AgyProvider().generate(
+        GenRequest(prompt="a red apple", raw=raw, chroma_key=key), tmp_path
+    )
+    prompt = spawn["cmd"][spawn["cmd"].index("-p") + 1]
+    # Positive half: the exact key the orchestrator will matte out, named and hexed.
+    assert hex_value in prompt and key in prompt
+    assert "FLAT" in prompt and "UNIFORM" in prompt
+    # Negative half: the measured failure mode is the agent helpfully matting for us.
+    assert "Do NOT run rembg" in prompt
+    assert "OPAQUE" in prompt
+    assert "checkerboard" in prompt
+
+
+def test_a_non_transparent_run_still_forbids_self_matting(tmp_path, spawn) -> None:
+    """Regression: the anti-rembg half must NOT be gated on `chroma_key`.
+
+    `gen_set.run_gen_cli`, `reroll` and `interpolate.gen_interpolator` all call
+    `generate_image` without `transparent=True` (their prompts carry the run's own key
+    and `extract` mattes later), so gating this half on the key left every pipeline row
+    unprotected against the exact unasked-for segmentation this design exists to stop.
+    """
+    raw = tmp_path / "raw.png"
+    spawn["writes"] = [(raw, _png_bytes())]
+    agy.AgyProvider().generate(GenRequest(prompt="a red apple on #00FF00", raw=raw), tmp_path)
+    prompt = spawn["cmd"][spawn["cmd"].index("-p") + 1]
+    assert "Do NOT run rembg" in prompt and "OPAQUE" in prompt
+    # …but no colour is named: the caller's prompt owns the backdrop here, and gen's
+    # own `chroma_key` default would be a guess that could contradict a green run.
+    assert "chroma-key backdrop" not in prompt
+    assert "#FF00FF" not in prompt and "magenta" not in prompt
+    assert "a red apple on #00FF00" in prompt
+
+
+def test_the_row_pipeline_default_call_still_carries_the_anti_rembg_rule(tmp_path, monkeypatch) -> None:
+    """End-to-end through `generate_image` with NO `transparent` argument at all.
+
+    This is exactly how `gen_set` / `reroll` / `interpolate` invoke it.
+    """
+    seen: dict = {}
+
+    def fake_run(cmd, **kwargs):
+        seen["prompt"] = cmd[cmd.index("-p") + 1]
+        Path(kwargs["cwd"], "raw.png").write_bytes(_png_bytes())
+        return _Completed(_envelope("saved"))
+
+    monkeypatch.setattr(agy.subprocess, "run", fake_run)
+    gen.generate_image("agy", "a walk row on flat green", tmp_path / "out.png")
+    assert "Do NOT run rembg" in seen["prompt"]
+    assert "segmentation, matting or cutout tool" in seen["prompt"]
+
+
+def test_an_unknown_chroma_key_fails_before_the_model_runs(tmp_path, spawn) -> None:
+    with pytest.raises(SystemExit, match="unknown chroma key 'cyan'"):
+        agy.AgyProvider().generate(
+            GenRequest(prompt="p", raw=tmp_path / "raw.png", chroma_key="cyan"), tmp_path
+        )
+    assert spawn["cmd"] is None
+
+
+def test_the_orchestrator_hands_the_provider_the_key_it_will_matte_out(tmp_path, monkeypatch) -> None:
+    """The painted backdrop and the matte must come from one decision, not two."""
+    seen: dict = {}
+
+    class _Recorder:
+        name = "agy"
+        transparency = TRANSPARENCY_CHROMA
+
+        def generate(self, request, workdir):
+            seen["chroma_key"] = request.chroma_key
+            seen["native_alpha"] = request.native_alpha
+            # Paint the key the orchestrator asked for, so key_transparent succeeds.
+            Image.new("RGB", (8, 8), (0, 255, 0)).save(request.raw)
+            from sprite_gen.gen.base import ProviderRun
+
+            return ProviderRun(provider="agy", elapsed_seconds=0.1)
+
+    monkeypatch.setattr(gen, "_make_provider", lambda *a, **k: _Recorder())
+    result = gen.generate_image(
+        "agy", "p", tmp_path / "out.png", transparent=True, chroma_key="green"
+    )
+    assert seen == {"chroma_key": "green", "native_alpha": False}
+    assert result.alpha["strategy"] == "chroma" and result.chroma["key"] == "green"
+
+
+def test_no_chroma_key_is_passed_when_the_run_is_not_transparent(tmp_path, spawn) -> None:
+    raw = tmp_path / "raw.png"
+    spawn["writes"] = [(raw, _png_bytes())]
+    run = agy.AgyProvider().generate(GenRequest(prompt="p", raw=raw), tmp_path)
+    assert run.extra["chroma_key_requested"] is None
+
+
+def test_references_are_added_to_the_workspace_and_named_in_the_prompt(tmp_path, spawn) -> None:
+    refs_dir = tmp_path / "refs"
+    refs_dir.mkdir()
+    ref = refs_dir / "identity.png"
+    ref.write_bytes(_png_bytes())
+    raw = tmp_path / "raw.png"
+    spawn["writes"] = [(raw, _png_bytes())]
+
+    agy.AgyProvider().generate(GenRequest(prompt="p", raw=raw, refs=[ref]), tmp_path)
+
+    cmd = spawn["cmd"]
+    add_dirs = [cmd[i + 1] for i, token in enumerate(cmd) if token == "--add-dir"]
+    assert add_dirs == [str(raw.parent), str(refs_dir)], "output dir plus each ref dir, deduplicated"
+    assert str(ref.resolve()) in cmd[cmd.index("-p") + 1]
+
+
+def test_missing_reference_fails_before_the_spawn(tmp_path, spawn) -> None:
+    with pytest.raises(SystemExit, match="reference image not found"):
+        agy.AgyProvider().generate(
+            GenRequest(prompt="p", raw=tmp_path / "raw.png", refs=[tmp_path / "nope.png"]),
+            tmp_path,
+        )
+    assert spawn["cmd"] is None
+
+
+def test_provider_run_uses_the_scrubbed_env_and_resolved_binary(tmp_path, spawn, monkeypatch) -> None:
+    monkeypatch.setenv("ORCHESTRATOR_RUNTIME_ENDPOINT_ID", "synthetic-endpoint")
+    monkeypatch.setattr(agy, "provider_binary", lambda _name: "C:/bin/agy.CMD")
+    raw = tmp_path / "raw.png"
+    spawn["writes"] = [(raw, _png_bytes())]
+
+    agy.AgyProvider().generate(GenRequest(prompt="p", raw=raw), tmp_path)
+
+    assert spawn["cmd"][0] == "C:/bin/agy.CMD"
+    assert "ORCHESTRATOR_RUNTIME_ENDPOINT_ID" not in spawn["kwargs"]["env"]
+    assert spawn["kwargs"]["encoding"] == "utf-8"
+
+
+# --- success reporting --------------------------------------------------------
+
+
+def test_success_publishes_the_named_file_and_reports_the_envelope(tmp_path, spawn) -> None:
+    raw = tmp_path / "raw.png"
+    spawn["writes"] = [(raw, _png_bytes())]
+    spawn["stdout"] = _envelope(f"Saved it.\n{raw}\n")
+
+    run = agy.AgyProvider().generate(GenRequest(prompt="p", raw=raw), tmp_path)
+
+    assert raw.read_bytes() == _png_bytes()
+    assert run.session_id == "479d0f29-6a7b-4250-bb21-4888554201b6"
+    assert run.extra["transport"] == "agy-cli"
+    assert run.extra["num_turns"] == 1
+    assert run.extra["usage"]["total_tokens"] == 81178
+    assert run.extra["agy_duration_seconds"] == 62.96
+    assert run.extra["reported_paths"] == [str(raw)]
+    assert run.extra["recovered_from"] is None
+    assert run.extra["chroma_key_requested"] is None
+    assert run.elapsed_seconds >= 0
+
+
+def test_a_stale_destination_from_an_earlier_run_is_never_republished(tmp_path, spawn) -> None:
+    """`--workdir` can be reused; only a file THIS run wrote may be published."""
+    raw = tmp_path / "raw.png"
+    raw.write_bytes(_png_bytes(color=(255, 0, 0, 255)))  # left over from a previous attempt
+    spawn["writes"] = []  # this run writes nothing
+
+    with pytest.raises(SystemExit, match="no usable generated image"):
+        agy.AgyProvider().generate(GenRequest(prompt="p", raw=raw), tmp_path)
+    assert not raw.exists()
+
+
+def test_a_file_saved_elsewhere_is_recovered_from_the_reported_path(tmp_path, spawn) -> None:
+    raw = tmp_path / "raw.png"
+    elsewhere = tmp_path / "image test" / "boy.png"
+    spawn["writes"] = [(elsewhere, _png_bytes())]
+    spawn["stdout"] = _envelope(
+        "Here you go: [boy.png](file:///"
+        + str(elsewhere).replace("\\", "/").replace(" ", "%20")
+        + ")\n"
+    )
+
+    run = agy.AgyProvider().generate(GenRequest(prompt="p", raw=raw), tmp_path)
+
+    assert raw.read_bytes() == _png_bytes()
+    assert run.extra["recovered_from"], "the recovery route is recorded, not silent"
+
+
+# --- failure modes ------------------------------------------------------------
+
+
+def test_non_success_status_fails_loudly(tmp_path, spawn) -> None:
+    spawn["stdout"] = _envelope("quota exhausted", status="ERROR")
+    with pytest.raises(SystemExit, match="status='ERROR'"):
+        agy.AgyProvider().generate(GenRequest(prompt="p", raw=tmp_path / "raw.png"), tmp_path)
+
+
+def test_success_without_any_file_fails_and_names_what_was_claimed(tmp_path, spawn) -> None:
+    spawn["stdout"] = _envelope("All done! Saved to C:/nowhere/ghost.png\n")
+    with pytest.raises(SystemExit) as exc:
+        agy.AgyProvider().generate(GenRequest(prompt="p", raw=tmp_path / "raw.png"), tmp_path)
+    assert "no usable generated image" in str(exc.value)
+    assert "ghost.png" in str(exc.value)
+
+
+def test_non_png_bytes_at_the_destination_are_refused(tmp_path, spawn) -> None:
+    raw = tmp_path / "raw.png"
+    spawn["writes"] = [(raw, b"JFIF not a png")]
+    with pytest.raises(SystemExit, match="not a PNG"):
+        agy.AgyProvider().generate(GenRequest(prompt="p", raw=raw), tmp_path)
+
+
+def test_non_zero_exit_reports_stderr(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        agy.subprocess,
+        "run",
+        lambda cmd, **kw: _Completed("", returncode=2, stderr="not signed in"),
+    )
+    with pytest.raises(SystemExit, match="agy exited 2"):
+        agy.AgyProvider().generate(GenRequest(prompt="p", raw=tmp_path / "raw.png"), tmp_path)
+
+
+def test_missing_json_envelope_fails_instead_of_guessing(tmp_path, spawn) -> None:
+    spawn["stdout"] = "I saved the image, trust me.\n"
+    with pytest.raises(SystemExit, match="printed no JSON envelope"):
+        agy.AgyProvider().generate(GenRequest(prompt="p", raw=tmp_path / "raw.png"), tmp_path)
+
+
+def test_envelope_survives_a_banner_line_before_the_json(tmp_path, spawn) -> None:
+    raw = tmp_path / "raw.png"
+    spawn["writes"] = [(raw, _png_bytes())]
+    spawn["stdout"] = "A new version of agy is available!\n" + _envelope(str(raw))
+    run = agy.AgyProvider().generate(GenRequest(prompt="p", raw=raw), tmp_path)
+    assert run.extra["num_turns"] == 1
+
+
+def test_timeout_raises_the_observable_gen_timeout(tmp_path, spawn) -> None:
+    spawn["raise"] = subprocess.TimeoutExpired(cmd="agy", timeout=agy.AGY_GEN_TIMEOUT_SECONDS)
+    with pytest.raises(GenTimeoutError) as exc:
+        agy.AgyProvider().generate(GenRequest(prompt="p", raw=tmp_path / "raw.png"), tmp_path)
+    # The message must name the measured normal duration and the real stall cause.
+    assert "~63s" in str(exc.value) and "always-proceed" in str(exc.value)
+
+
+def test_the_timeout_clears_agys_own_print_timeout(tmp_path) -> None:
+    """agy's own `--print-timeout` default is 5m; our hard kill must sit above it."""
+    assert agy.AGY_GEN_TIMEOUT_SECONDS > 300
+
+
+# --- prose path parsing -------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "response, expected",
+    [
+        ("D:\\runs\\raw.png\n", "D:\\runs\\raw.png"),
+        ("  `/home/u/out/raw.png`  \n", "/home/u/out/raw.png"),
+        ("see [boy.png](file:///D:/a/image%20test/boy.png)", "D:/a/image test/boy.png"),
+        ("**File:** boy.png\n**Folder:** D:/a/out\n", "D:/a/out/boy.png"),
+        ("saved [it](D:/a/out/boy.webp) ok", "D:/a/out/boy.webp"),
+    ],
+)
+def test_reported_paths_reads_every_observed_prose_shape(response, expected) -> None:
+    found = agy.reported_paths(response)
+    assert any(Path(p) == Path(expected) for p in found), found
+
+
+def test_reported_paths_is_deduplicated_and_ignores_non_images() -> None:
+    response = (
+        "I ran `pip install rembg` then wrote /out/raw.png\n"
+        "[raw.png](file:///out/raw.png)\n"
+        "Logs are at /out/session.log\n"
+    )
+    found = agy.reported_paths(response)
+    assert [Path(p) for p in found] == [Path("/out/raw.png")]
+
+
+def test_file_folder_details_pair_by_position_not_by_cross_product() -> None:
+    """Regression: two details blocks must not produce file A under folder B.
+
+    A cross-joined path that happens to name a real file inside an `--add-dir`
+    workspace would be copied out and published as the result, and `verify_png` only
+    proves it is a PNG — not that it is the right one.
+    """
+    response = "\n".join(
+        [
+            "First save:",
+            "**File:** apple.png",
+            "**Folder:** D:/out/one",
+            "",
+            "Second save:",
+            "**File:** pear.png",
+            "**Folder:** D:/out/two",
+            "",
+        ]
+    )
+    found = [Path(p) for p in agy.reported_paths(response)]
+    assert Path("D:/out/one/apple.png") in found
+    assert Path("D:/out/two/pear.png") in found
+    assert Path("D:/out/two/apple.png") not in found
+    assert Path("D:/out/one/pear.png") not in found
+
+
+def test_folder_before_file_still_pairs_correctly() -> None:
+    response = "\n".join(["**Folder:** /out/a", "**File:** one.png", ""])
+    assert Path("/out/a/one.png") in [Path(p) for p in agy.reported_paths(response)]
+
+
+def test_an_absolute_file_detail_is_not_joined_to_a_folder() -> None:
+    response = "\n".join(["**File:** D:/elsewhere/boy.png", "**Folder:** D:/out/one", ""])
+    found = [Path(p) for p in agy.reported_paths(response)]
+    assert found == [Path("D:/elsewhere/boy.png")]
+
+
+# --- recovery containment (untrusted paths out of agent prose) -----------------
+
+
+def test_a_real_file_outside_the_workspace_is_refused_not_copied(tmp_path, spawn) -> None:
+    """Regression: recovery must not publish a file from outside the workspace.
+
+    `verify_png` proves a file is a PNG, never that it is the right PNG — so an
+    absolute path in the agent's prose naming any readable image on the machine
+    would otherwise be copied in and published as the sprite.
+    """
+    work = tmp_path / "work"
+    work.mkdir()
+    outsider = tmp_path / "elsewhere" / "secret.png"
+    outsider.parent.mkdir()
+    outsider.write_bytes(_png_bytes(color=(1, 2, 3, 255)))
+
+    raw = work / "raw.png"
+    spawn["writes"] = []  # the instructed destination is never written
+    spawn["stdout"] = _envelope(f"Saved it to:\n{outsider}\n")
+
+    with pytest.raises(SystemExit) as exc:
+        agy.AgyProvider().generate(GenRequest(prompt="p", raw=raw), work)
+
+    assert not raw.exists(), "nothing may be published from outside the workspace"
+    message = str(exc.value)
+    assert "outside the workspace" in message
+    assert "no usable generated image" in message
+
+
+def test_dot_dot_traversal_out_of_the_workspace_is_refused(tmp_path, spawn) -> None:
+    work = tmp_path / "work"
+    work.mkdir()
+    outsider = tmp_path / "outside.png"
+    outsider.write_bytes(_png_bytes())
+    raw = work / "raw.png"
+    spawn["writes"] = []
+    spawn["stdout"] = _envelope("Saved it: [out](../outside.png)\n")
+
+    with pytest.raises(SystemExit, match="no usable generated image"):
+        agy.AgyProvider().generate(GenRequest(prompt="p", raw=raw), work)
+    assert not raw.exists()
+
+
+def test_a_symlink_inside_the_workspace_pointing_outside_is_refused(tmp_path, spawn) -> None:
+    """`_resolve_candidate` resolves before the check, so the target decides."""
+    work = tmp_path / "work"
+    work.mkdir()
+    outsider = tmp_path / "outside.png"
+    outsider.write_bytes(_png_bytes())
+    link = work / "linked.png"
+    try:
+        link.symlink_to(outsider)
+    except (OSError, NotImplementedError):  # Windows without developer mode
+        pytest.skip("symlink creation is not permitted in this environment")
+
+    raw = work / "raw.png"
+    spawn["writes"] = []
+    spawn["stdout"] = _envelope(f"Saved it to:\n{link}\n")
+
+    with pytest.raises(SystemExit, match="outside the workspace"):
+        agy.AgyProvider().generate(GenRequest(prompt="p", raw=raw), work)
+    assert not raw.exists()
+
+
+def test_a_reference_image_is_never_recovered_as_the_output(tmp_path, spawn) -> None:
+    """Republishing an input as this run's generation is the wrong-file outcome."""
+    work = tmp_path / "work"
+    work.mkdir()
+    ref = work / "identity.png"  # deliberately inside the workspace
+    ref.write_bytes(_png_bytes())
+    raw = work / "raw.png"
+    spawn["writes"] = []
+    spawn["stdout"] = _envelope(f"Used this file:\n{ref}\n")
+
+    with pytest.raises(SystemExit) as exc:
+        agy.AgyProvider().generate(GenRequest(prompt="p", raw=raw, refs=[ref]), work)
+    assert "reference image, not the output" in str(exc.value)
+    assert not raw.exists()
+
+
+def test_recovery_still_works_for_a_file_inside_the_workspace(tmp_path, spawn) -> None:
+    """The containment check must not break the legitimate recovery path."""
+    work = tmp_path / "work"
+    work.mkdir()
+    elsewhere = work / "renders" / "apple.png"
+    spawn["writes"] = [(elsewhere, _png_bytes())]
+    spawn["stdout"] = _envelope(f"Saved it to:\n{elsewhere}\n")
+
+    raw = work / "raw.png"
+    run = agy.AgyProvider().generate(GenRequest(prompt="p", raw=raw), work)
+    assert raw.read_bytes() == _png_bytes()
+    assert run.extra["recovered_from"]


### PR DESCRIPTION
## Summary

Adds `AgyProvider`, a third `gen` provider backed by Google's **Antigravity CLI** (`agy`) — a subscription/OAuth-authenticated general-purpose agent, no API key required. Sits alongside the existing OAuth-based `codex` provider and API/CLI-login-based `grok` provider.

## Why chroma, not native alpha

agy's underlying model cannot return alpha directly. An earlier design left it unbriefed and it autonomously downloaded and ran `rembg` to segment the image itself — non-deterministic (different tool/parameters/skipped step each run) and ~2x slower on a cold model download.

This version instead instructs agy to paint the subject on a flat chroma-key backdrop and lets sprite-gen's own tested `key_transparent()` matte it out deterministically, exactly like the `grok` provider (`transparency = TRANSPARENCY_CHROMA`). The reasoning for *not* trusting the agent's own judgment on transparency is stated explicitly in the module docstring and in the prompt itself.

## Untrusted-response handling

Since agy is an agent (not a bare API), its response is free-text prose. The primary contract is that agy is told the exact absolute destination path to write, and success is decided by **what's actually on disk**, never by what the agent says (matches this codebase's existing `verify_png`/"No Silent Fallback" philosophy). Prose-parsing (markdown links, `file://` URLs, `**File:**`/`**Folder:**` pairs, bare paths) exists only as a recovery route for when the instructed path wasn't written.

Recovery-path hardening, found via review and fixed here (regression-tested):
- File/Folder detail pairs are matched **positionally** (nearest before/after), not as a cross product, so a response with 2+ pairs can't produce a wrong file+folder combination.
- Every recovered candidate must resolve **inside `write_roots`** (output dir + agent's working dir — deliberately narrower than the read+write `--add-dir` grant, which also covers reference-image directories) before being copied and published. A reference image is never eligible as a recovered output. Resolving before the check normalizes `..` traversal and follows symlinks to their real target — closes a path-traversal/wrong-file-published risk that existed before this hardening.
- The anti-self-matting instruction is now **unconditional** on every agy run, not just `--transparent` runs — closes a gap where the row/reroll/interpolate pipelines could select agy without ever emitting the rule.

## Security posture (stated, not hidden)

The anti-self-matting instruction is prose, not enforcement. Nothing sandboxes or rate-limits what the agy agent does with its granted shell access, and it has already installed and run a tool unprompted once during testing. See the module docstring and `docs/gen.md`'s "Security note" for what is and isn't actually guaranteed at this layer — this is a design tradeoff of using an agentic CLI as a provider, stated explicitly for anyone deploying it.

## Other fixes this exposed

- `catalog.py`'s provider-label lookup used `zip()`, which silently truncates — would have dropped a third provider's label. Replaced with a name-keyed dict that fails loudly instead.
- `access.py`'s provider probe raised on any non-codex/grok name — would have crashed the workflow guide. Added a PATH-presence-only branch (no login-status probe, to avoid spending user quota from a read-only guide).

## Testing

- 40 new tests in `tests/gen/test_agy_provider.py`.
- Full suite: 1549 passed, same 47 pre-existing Windows-only failures as a clean `main` baseline (diffed directly) — zero regressions.
- Verified live end-to-end three times against the real `agy` CLI, with independent Pillow pixel reads confirming genuine alpha=0/255 output (not just trusting agy's or sprite-gen's own self-reported success).

## Requirements to actually use this provider

`agy` installed and authenticated (Google AI Pro / Antigravity subscription), with `Tool Permission` set to `always-proceed` via `agy`'s `/config` — otherwise headless (`--print`/`gen` CLI) invocations get auto-denied on tool-call approval. Not added to `SKILL.md`'s `required_bins` since it's an optional provider, matching how `grok` is handled.
